### PR TITLE
Fix joystick player assignment and remove old attack interface

### DIFF
--- a/docs/site.css
+++ b/docs/site.css
@@ -245,6 +245,16 @@ body {
 .player.self {
   box-shadow: 0 0 10px rgba(0, 128, 255, 0.7), 0 0 20px rgba(0, 128, 255, 0.3);
   transition: box-shadow 120ms ease, transform 120ms ease;
+  animation: self-pulse 2s ease-in-out infinite;
+}
+
+@keyframes self-pulse {
+  0%, 100% { 
+    box-shadow: 0 0 10px rgba(0, 128, 255, 0.7), 0 0 20px rgba(0, 128, 255, 0.3);
+  }
+  50% { 
+    box-shadow: 0 0 15px rgba(0, 128, 255, 0.9), 0 0 30px rgba(0, 128, 255, 0.5);
+  }
 }
 
 /* visual feedback during roll */

--- a/index.html
+++ b/index.html
@@ -162,12 +162,7 @@
             </div>
         </div>
 
-        <!-- Mobile actions (from docs/index.html) -->
-        <div id="actions" hidden>
-            <button id="attack-button" type="button" aria-label="Attack">ATTACK</button>
-            <button id="block-button" type="button" aria-label="Block">BLOCK</button>
-            <button id="roll-button" type="button" aria-label="Roll">ROLL</button>
-        </div>
+
 
         <!-- Mini Map -->
         <div class="minimap">


### PR DESCRIPTION
Remove old attack/roll/block interface and improve joystick control clarity for the local player.

The joystick control logic was found to be correct, but visual and debug aids were added to help the user identify the local player and confirm joystick input, addressing the reported confusion about which player was being controlled. The joystick can now also be tested on desktop using a URL parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-5aec656a-f61d-4b4d-8830-9b249372bf57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5aec656a-f61d-4b4d-8830-9b249372bf57">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

