### PR TITLE
Simplify action buttons on DozedEnt

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,18 +86,8 @@
 
         <!-- Mobile Controls -->
         <div class="mobile-controls">
-            <!-- Left Side: D-Pad -->
+            <!-- Left Side: Settings Button -->
             <div class="left-controls">
-                <div class="dpad-container">
-                    <div class="dpad">
-                        <button class="dpad-btn dpad-up" data-direction="up">▲</button>
-                        <button class="dpad-btn dpad-right" data-direction="right">▶</button>
-                        <button class="dpad-btn dpad-down" data-direction="down">▼</button>
-                        <button class="dpad-btn dpad-left" data-direction="left">◀</button>
-                        <div class="dpad-center"></div>
-                    </div>
-                </div>
-                
                 <!-- Settings Button -->
                 <button class="settings-btn" onclick="toggleSettings()">⚙️</button>
             </div>
@@ -110,53 +100,20 @@
                         <span class="btn-icon">⚔️</span>
                         <span class="cooldown"></span>
                     </button>
-                    <button class="action-btn secondary" data-action="jump">
-                        <span class="btn-icon">↑</span>
+                    <button class="action-btn secondary" data-action="roll">
+                        <span class="btn-icon">🌀</span>
                         <span class="cooldown"></span>
                     </button>
-                    <button class="action-btn tertiary" data-action="dodge">
-                        <span class="btn-icon">💨</span>
+                    <button class="action-btn tertiary" data-action="block">
+                        <span class="btn-icon">🛡️</span>
                         <span class="cooldown"></span>
-                    </button>
-                </div>
-
-                <!-- Skill Buttons -->
-                <div class="skill-buttons">
-                    <button class="skill-btn" data-skill="1">
-                        <span class="skill-icon">🔥</span>
-                        <span class="skill-cooldown">3</span>
-                    </button>
-                    <button class="skill-btn" data-skill="2">
-                        <span class="skill-icon">❄️</span>
-                        <span class="skill-cooldown"></span>
-                    </button>
-                    <button class="skill-btn" data-skill="3">
-                        <span class="skill-icon">⚡</span>
-                        <span class="skill-cooldown"></span>
-                    </button>
-                    <button class="skill-btn ultimate" data-skill="ultimate">
-                        <span class="skill-icon">💥</span>
-                        <span class="skill-cooldown"></span>
-                        <div class="ultimate-glow"></div>
-                    </button>
-                </div>
-
-                <!-- Quick Items -->
-                <div class="quick-items">
-                    <button class="item-btn" data-item="potion">
-                        <span class="item-icon">🧪</span>
-                        <span class="item-count">5</span>
-                    </button>
-                    <button class="item-btn" data-item="bomb">
-                        <span class="item-icon">💣</span>
-                        <span class="item-count">3</span>
                     </button>
                 </div>
             </div>
         </div>
 
         <!-- Mobile joystick (from docs/index.html) -->
-        <div id="joystick" hidden>
+        <div id="joystick">
             <div id="joystick-base">
                 <div id="joystick-knob"></div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -386,6 +386,67 @@ body {
     text-align: center;
 }
 
+/* Mobile joystick */
+#joystick {
+    position: fixed;
+    left: 20px;
+    bottom: 20px;
+    z-index: 20;
+}
+
+#joystick[hidden] {
+    display: none;
+}
+
+#joystick-base {
+    position: relative;
+    width: 140px;
+    height: 140px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    border: 2px solid rgba(255, 255, 255, 0.25);
+    touch-action: none;
+}
+
+#joystick-knob {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.9);
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    transition: none;
+}
+
+@media (max-width: 768px) {
+    #joystick-base {
+        width: 120px;
+        height: 120px;
+    }
+    #joystick-knob {
+        width: 56px;
+        height: 56px;
+    }
+}
+
+@media (max-width: 480px) {
+    #joystick {
+        left: 12px;
+        bottom: 12px;
+    }
+    #joystick-base {
+        width: 100px;
+        height: 100px;
+    }
+    #joystick-knob {
+        width: 48px;
+        height: 48px;
+    }
+}
+
 /* Minimap */
 .minimap {
     position: absolute;


### PR DESCRIPTION
Simplify mobile controls by removing the D-pad and all but three action buttons (Attack, Roll, Block), and implementing a functional joystick.

---
<a href="https://cursor.com/background-agent?bcId=bc-d95f783d-3c88-4508-ba43-c23d599fb330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d95f783d-3c88-4508-ba43-c23d599fb330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

