### PR TITLE
Fix unresponsive start game button

### DIFF
--- a/site.js
+++ b/site.js
@@ -91,6 +91,16 @@ try {
   } catch {}
 } catch (e) {
   console.warn('WASM unavailable; core simulation requires WASM:', e)
+  
+  // Enable start game button even without WASM (for testing/debugging)
+  const startGameBtn = document.getElementById('start-game-btn')
+  if (startGameBtn) {
+    startGameBtn.disabled = false
+    startGameBtn.textContent = 'Start Game (No WASM)'
+    startGameBtn.style.background = '#ff6b6b'
+    startGameBtn.style.cursor = 'pointer'
+    console.log('WASM failed to load - Start Game button enabled with fallback')
+  }
 }
 
 const byId = document.getElementById.bind(document)
@@ -288,7 +298,7 @@ function showRoomInfo(room) {
       </div>
       <button onclick="leaveRoom()" style="padding: 5px 10px; background: #e74c3c; border: none; color: white; border-radius: 3px; cursor: pointer;">Leave Room</button>
       ${room.host === roomManager.localPlayer.id ? 
-        '<button onclick="startGame()" style="margin-left: 10px; padding: 5px 10px; background: #27ae60; border: none; color: white; border-radius: 3px; cursor: pointer;">Start Game</button>' : 
+        '<button onclick="startRoomGame()" style="margin-left: 10px; padding: 5px 10px; background: #27ae60; border: none; color: white; border-radius: 3px; cursor: pointer;">Start Game</button>' : 
         '<button onclick="toggleReady()" style="margin-left: 10px; padding: 5px 10px; background: #f39c12; border: none; color: white; border-radius: 3px; cursor: pointer;">Ready</button>'
       }
     </div>
@@ -301,7 +311,7 @@ window.leaveRoom = function() {
   updateRoomsList()
 }
 
-window.startGame = function() {
+window.startRoomGame = function() {
   if (!roomManager) return
   try {
     roomManager.startGame()
@@ -2293,6 +2303,7 @@ function startGame() {
   // Check if WASM is loaded
   if (!wasmExports || typeof wasmExports.update !== 'function') {
     console.warn('Cannot start game: WASM not loaded yet')
+    alert('Game cannot start: WASM engine not loaded. Please refresh the page and try again.')
     return
   }
   


### PR DESCRIPTION
Fix 'Start Game' button malfunction by resolving a function name conflict and enhancing WASM loading error handling.

The "Start Game" button was non-functional because `window.startGame` was defined twice, with the main game initialization function overriding the multiplayer room management function. Additionally, if WASM failed to load, the button would remain disabled or silently fail, providing no user feedback. This PR renames the multiplayer function, updates its call site, and adds explicit error messages and button state changes for WASM loading issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ba9904d-9c03-436c-82d0-8281a735996f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ba9904d-9c03-436c-82d0-8281a735996f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

