### PR TITLE
Fix module loading errors

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,25 @@
+# MIME type configuration for JavaScript modules
+# This ensures JavaScript files are served with correct MIME types
+
+# ES Modules
+AddType application/javascript .js
+AddType application/javascript .mjs
+
+# WASM files
+AddType application/wasm .wasm
+
+# JSON files
+AddType application/json .json
+
+# CSS files
+AddType text/css .css
+
+# HTML files
+AddType text/html .html
+
+# Enable CORS for modules
+<IfModule mod_headers.c>
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, POST, OPTIONS"
+    Header set Access-Control-Allow-Headers "Content-Type"
+</IfModule>

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,2 @@
+# This file tells GitHub Pages to bypass Jekyll processing
+# This is necessary to serve JavaScript files with correct MIME types

--- a/MIME_TYPE_FIX.md
+++ b/MIME_TYPE_FIX.md
@@ -1,0 +1,64 @@
+# GitHub Pages MIME Type Fix
+
+## Problem
+JavaScript modules were being served with incorrect MIME type (`text/html` instead of `application/javascript`) on GitHub Pages, causing module loading failures.
+
+## Root Cause
+GitHub Pages uses Jekyll by default, which processes all files and can interfere with JavaScript module serving. The `.js` files were being treated as HTML files.
+
+## Solution Applied
+
+### 1. Created `.nojekyll` file
+- Added `.nojekyll` file to bypass Jekyll processing entirely
+- This ensures GitHub Pages serves files as-is without Jekyll interference
+
+### 2. Updated `_config.yml`
+- Added JavaScript file patterns to the `defaults` section with `layout: null`
+- This disables Jekyll processing for all `.js` files
+- Added `src/` and `dist/` folders to the `include` section
+
+### 3. Created `.htaccess` file
+- Added explicit MIME type declarations (for non-GitHub Pages hosting)
+- Includes CORS headers for module loading
+
+### 4. Built the project
+- Ran `npm run build:all` to create the `dist/` folder with bundled modules
+- Generated `trystero-mqtt.min.js` and other required modules
+
+## Files Modified/Created
+
+1. **`.nojekyll`** - New file to bypass Jekyll
+2. **`_config.yml`** - Updated to handle JavaScript files properly
+3. **`.htaccess`** - New file with MIME type configuration
+4. **`test-mime.html`** - Test file to verify module loading
+5. **`dist/`** - Built folder with bundled modules
+
+## Testing
+
+Use `test-mime.html` to verify that modules load correctly:
+- Opens the file in a browser
+- Attempts to load `trystero-mqtt.min.js` and other modules
+- Shows success/failure messages in console and on page
+
+## Deployment Steps
+
+1. Commit all changes to your repository
+2. Push to the main branch
+3. GitHub Pages will automatically deploy
+4. Test the live site to ensure modules load correctly
+
+## Expected Results
+
+After deployment:
+- JavaScript modules should load with correct MIME types
+- No more "MIME type interdit" errors
+- ES modules should work properly in browsers
+- The game should load and function correctly
+
+## Troubleshooting
+
+If issues persist:
+1. Check browser developer tools for any remaining MIME type errors
+2. Verify `.nojekyll` file is present in the repository root
+3. Ensure `dist/` folder is committed and contains the built files
+4. Check GitHub Pages settings to ensure it's serving from the correct branch

--- a/_config.yml
+++ b/_config.yml
@@ -32,11 +32,25 @@ include:
   - game.wasm
   - images
   - effects
+  - src/
+  - dist/
 
 # Disable Jekyll processing for certain files
 defaults:
   - scope:
       path: "*.wasm"
+    values:
+      layout: null
+  - scope:
+      path: "*.js"
+    values:
+      layout: null
+  - scope:
+      path: "src/**/*.js"
+    values:
+      layout: null
+  - scope:
+      path: "dist/**/*.js"
     values:
       layout: null
   - scope:

--- a/test-mime.html
+++ b/test-mime.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MIME Type Test</title>
+</head>
+<body>
+    <h1>MIME Type Test</h1>
+    <p>This page tests if JavaScript modules are served with correct MIME types.</p>
+    
+    <script type="module">
+        // Test loading the trystero-mqtt module
+        try {
+            const module = await import('./dist/trystero-mqtt.min.js');
+            console.log('✅ trystero-mqtt.min.js loaded successfully');
+            console.log('Module exports:', Object.keys(module));
+        } catch (error) {
+            console.error('❌ Failed to load trystero-mqtt.min.js:', error);
+            document.body.innerHTML += '<p style="color: red;">❌ Failed to load trystero-mqtt.min.js: ' + error.message + '</p>';
+        }
+        
+        // Test loading other modules
+        try {
+            const rngModule = await import('./src/utils/rng.js');
+            console.log('✅ rng.js loaded successfully');
+        } catch (error) {
+            console.error('❌ Failed to load rng.js:', error);
+            document.body.innerHTML += '<p style="color: red;">❌ Failed to load rng.js: ' + error.message + '</p>';
+        }
+        
+        try {
+            const gameRendererModule = await import('./src/utils/game-renderer.js');
+            console.log('✅ game-renderer.js loaded successfully');
+        } catch (error) {
+            console.error('❌ Failed to load game-renderer.js:', error);
+            document.body.innerHTML += '<p style="color: red;">❌ Failed to load game-renderer.js: ' + error.message + '</p>';
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fix GitHub Pages MIME type errors for JavaScript modules by bypassing Jekyll processing.

GitHub Pages was serving `.js` files with `text/html` MIME type because Jekyll was processing them. This PR adds a `.nojekyll` file and updates `_config.yml` to ensure `.js` files are served with the correct `application/javascript` MIME type, allowing ES modules to load.

---
<a href="https://cursor.com/background-agent?bcId=bc-29037af7-f85f-4979-baf9-6efa07109acd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-29037af7-f85f-4979-baf9-6efa07109acd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

