### PR TITLE
Fix joystick player movement

### DIFF
--- a/site.js
+++ b/site.js
@@ -191,7 +191,7 @@ class GameApplication {
 
       // Initialize enhanced mobile controls
       console.log('🔧 Initializing enhanced mobile controls...');
-      this.enhancedMobileControls = new EnhancedMobileControls(this.gameStateManager);
+      this.enhancedMobileControls = new EnhancedMobileControls(this.gameStateManager, this.inputManager);
       console.log('✅ Enhanced mobile controls initialized');
 
       // Setup event listeners

--- a/src/game/game-state-manager.js
+++ b/src/game/game-state-manager.js
@@ -380,10 +380,12 @@ export class GameStateManager {
   updateMovement(x, y) {
     if (!this.wasmManager) return;
 
-    // Send movement to WASM
-    if (typeof this.wasmManager.setPlayerInput === 'function') {
-      this.wasmManager.setPlayerInput(x, y, 0, 0, 0, 0, 0, 0);
-    }
+    // Store movement input for the next WASM update cycle
+    this.playerState.direction = { x, y };
+    
+    // The movement will be processed in the next WASM update cycle
+    // via the InputManager's sendInputToWasm method
+    console.log('Movement input updated:', { x, y });
   }
 
   /**

--- a/src/input/enhanced-mobile-controls.js
+++ b/src/input/enhanced-mobile-controls.js
@@ -4,8 +4,9 @@
  */
 
 export class EnhancedMobileControls {
-  constructor(gameStateManager) {
+  constructor(gameStateManager, inputManager = null) {
     this.gameStateManager = gameStateManager;
+    this.inputManager = inputManager;
     this.touchPoints = new Map();
     this.gestureState = {
       swipeThreshold: 50,
@@ -660,6 +661,13 @@ export class EnhancedMobileControls {
    * Update movement input
    */
   updateMovementInput(x, y) {
+    // Update InputManager's input state (this is what gets sent to WASM)
+    if (this.inputManager && this.inputManager.inputState) {
+      this.inputManager.inputState.direction.x = x;
+      this.inputManager.inputState.direction.y = y;
+    }
+    
+    // Also update GameStateManager for consistency
     if (this.gameStateManager && this.gameStateManager.updateMovement) {
       this.gameStateManager.updateMovement(x, y);
     }
@@ -669,6 +677,28 @@ export class EnhancedMobileControls {
    * Trigger game action
    */
   triggerGameAction(action, pressed) {
+    // Update InputManager's input state for actions
+    if (this.inputManager && this.inputManager.inputState) {
+      switch (action) {
+        case 'lightAttack':
+          this.inputManager.inputState.lightAttack = pressed;
+          break;
+        case 'heavyAttack':
+          this.inputManager.inputState.heavyAttack = pressed;
+          break;
+        case 'special':
+          this.inputManager.inputState.special = pressed;
+          break;
+        case 'block':
+          this.inputManager.inputState.block = pressed;
+          break;
+        case 'roll':
+          this.inputManager.inputState.roll = pressed;
+          break;
+      }
+    }
+    
+    // Also call GameStateManager methods for consistency
     if (!this.gameStateManager) return;
     
     switch (action) {


### PR DESCRIPTION
Refactor mobile controls to directly update InputManager state, fixing joystick and action button input not reaching WASM.

The previous implementation had a disconnect where `EnhancedMobileControls` updated the `GameStateManager`, but the WASM module for player movement relied on the `InputManager`'s state. This PR ensures that mobile input directly updates the `InputManager`'s state, which is then correctly passed to WASM, enabling player movement and actions. The `GameStateManager.updateMovement` call was also attempting to call a non-existent WASM method, which has been removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-07b8fcca-2cac-416d-bd20-086be1746cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07b8fcca-2cac-416d-bd20-086be1746cf4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

