### PR TITLE
Fix joystick player movement

### DIFF
--- a/src/game/game-state-manager.js
+++ b/src/game/game-state-manager.js
@@ -378,11 +378,11 @@ export class GameStateManager {
    * @param {number} y - Movement direction Y (-1 to 1)
    */
   updateMovement(x, y) {
-    if (!this.wasmManager) return;
+    if (!this.wasmManager || !this.wasmManager.exports) return;
 
-    // Send movement to WASM
-    if (typeof this.wasmManager.setPlayerInput === 'function') {
-      this.wasmManager.setPlayerInput(x, y, 0, 0, 0, 0, 0, 0);
+    // Send movement to WASM via the correct API
+    if (typeof this.wasmManager.exports.set_player_input === 'function') {
+      this.wasmManager.exports.set_player_input(x, y, 0, 0, 0, 0, 0, 0);
     }
   }
 


### PR DESCRIPTION
Fix joystick input by calling the correct WASM `set_player_input` export in `GameStateManager.updateMovement`.

---
<a href="https://cursor.com/background-agent?bcId=bc-103964a5-f058-4442-a0c6-42f13dc87868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-103964a5-f058-4442-a0c6-42f13dc87868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

