### PR TITLE
Fix gamepad manager update error

### DIFF
--- a/src/input/gamepad-manager.js
+++ b/src/input/gamepad-manager.js
@@ -325,8 +325,18 @@ export class GamepadManager {
     
     const input = this.getProcessedInput();
     
-    // Update game state manager with gamepad input
-    if (this.gameStateManager.updateInput) {
+    // Update input manager with gamepad input
+    if (this.gameStateManager.inputState) {
+      // Update InputManager's input state directly
+      this.gameStateManager.inputState.direction.x = input.moveX;
+      this.gameStateManager.inputState.direction.y = input.moveY;
+      this.gameStateManager.inputState.lightAttack = input.lightAttack;
+      this.gameStateManager.inputState.heavyAttack = input.heavyAttack;
+      this.gameStateManager.inputState.special = input.special;
+      this.gameStateManager.inputState.roll = input.roll;
+      this.gameStateManager.inputState.block = input.block;
+    } else if (this.gameStateManager.updateInput) {
+      // Fallback to updateInput method if available
       this.gameStateManager.updateInput(input);
     }
   }
@@ -445,6 +455,13 @@ export class GamepadManager {
       activeGamepad: this.getActiveGamepadInfo(),
       config: this.config
     };
+  }
+  
+  /**
+   * Get number of connected gamepads
+   */
+  getConnectedCount() {
+    return this.gamepads.size;
   }
   
   /**

--- a/src/input/input-manager.js
+++ b/src/input/input-manager.js
@@ -508,9 +508,9 @@ export class InputManager {
      * Update gamepad input
      */
     updateGamepadInput() {
-        // Enhanced gamepad input is handled by GamepadManager
+        // Enhanced gamepad input is handled by GamepadManager's internal polling
+        // No need to manually update as it has its own requestAnimationFrame loop
         if (this.gamepadManager) {
-            this.gamepadManager.update();
             return;
         }
         


### PR DESCRIPTION
Remove manual gamepad update call from InputManager and integrate GamepadManager to directly update InputManager's state to fix `update is not a function` error.

The `GamepadManager` class manages its own input polling loop internally using `requestAnimationFrame`, so the `InputManager` should not attempt to call a manual `update()` method on it. This PR removes the erroneous call and updates the `GamepadManager` to directly modify the `InputManager`'s `inputState` object, ensuring correct and automatic gamepad input processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-85fb3639-f3da-4b06-b44f-8856298120cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85fb3639-f3da-4b06-b44f-8856298120cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

