### PR TITLE
Fix game imports in demo html

### DIFF
--- a/simple-player-demo.html
+++ b/simple-player-demo.html
@@ -487,7 +487,83 @@
                     }
                 };
                 
-                console.log('✓ WASM Systems initialized');
+                // Create mock WASM exports for the animation system
+                globalThis.wasmExports = {
+                    // Basic game state
+                    get_x: () => this.character ? this.character.x / this.canvas.width : 0.5,
+                    get_y: () => this.character ? this.character.y / this.canvas.height : 0.5,
+                    get_vel_x: () => this.character ? this.character.vx * 0.01 : 0,
+                    get_vel_y: () => this.character ? this.character.vy * 0.01 : 0,
+                    get_is_grounded: () => this.character ? (this.character.isGrounded ? 1 : 0) : 1,
+                    get_stamina: () => this.character ? this.character.stamina / 100 : 1,
+                    get_hp: () => this.character ? this.character.health / 100 : 1,
+                    get_player_anim_state: () => this.getAnimationStateCode(),
+                    
+                    // Enhanced animation data for realistic procedural animator
+                    get_anim_scale_x: () => 1.0,
+                    get_anim_scale_y: () => 1.0,
+                    get_anim_rotation: () => 0.0,
+                    get_anim_offset_x: () => 0.0,
+                    get_anim_offset_y: () => 0.0,
+                    get_anim_pelvis_y: () => Math.sin(this.wasmEngine.gameTime * 4) * 2,
+                    get_anim_spine_curve: () => Math.sin(this.wasmEngine.gameTime * 3) * 0.1,
+                    get_anim_shoulder_rotation: () => Math.sin(this.wasmEngine.gameTime * 2.5) * 0.05,
+                    get_anim_head_bob_x: () => Math.sin(this.wasmEngine.gameTime * 5) * 1.5,
+                    get_anim_head_bob_y: () => Math.cos(this.wasmEngine.gameTime * 5) * 1,
+                    get_anim_arm_swing_left: () => Math.sin(this.wasmEngine.gameTime * 6) * Math.PI * 0.3,
+                    get_anim_arm_swing_right: () => Math.sin(this.wasmEngine.gameTime * 6 + Math.PI) * Math.PI * 0.3,
+                    get_anim_leg_lift_left: () => Math.max(0, Math.sin(this.wasmEngine.gameTime * 8)),
+                    get_anim_leg_lift_right: () => Math.max(0, Math.sin(this.wasmEngine.gameTime * 8 + Math.PI)),
+                    get_anim_torso_twist: () => Math.sin(this.wasmEngine.gameTime * 4) * 0.02,
+                    get_anim_breathing_intensity: () => this.getBreathingIntensity(),
+                    get_anim_fatigue_factor: () => Math.max(0, 1 - this.character.stamina / 100),
+                    get_anim_momentum_x: () => this.character ? this.character.vx * 0.1 : 0,
+                    get_anim_momentum_y: () => this.character ? this.character.vy * 0.1 : 0,
+                    get_anim_cloth_sway: () => Math.sin(this.wasmEngine.gameTime * 3) * 0.5,
+                    get_anim_hair_bounce: () => this.character ? Math.abs(this.character.vy) * 0.1 : 0,
+                    get_anim_equipment_jiggle: () => this.character ? (Math.abs(this.character.vx) + Math.abs(this.character.vy)) * 0.05 : 0,
+                    get_anim_wind_response: () => Math.sin(this.wasmEngine.gameTime * 2) * 0.3,
+                    get_anim_ground_adapt: () => 0.0,
+                    get_anim_temperature_shiver: () => 0.0
+                };
+                
+                console.log('✓ WASM Systems initialized (Mock)');
+            }
+            
+            getAnimationStateCode() {
+                // Convert string states to numeric codes for WASM compatibility
+                if (!this.character) return 0; // Default to idle if no character
+                
+                switch(this.character.state) {
+                    case 'idle': return 0;
+                    case 'running': return 1;
+                    case 'attacking': return 2;
+                    case 'blocking': return 3;
+                    case 'rolling': return 4;
+                    case 'hurt': return 5;
+                    case 'dead': return 6;
+                    case 'jumping': return 7;
+                    case 'doubleJumping': return 8;
+                    case 'landing': return 9;
+                    case 'wallSliding': return 10;
+                    case 'dashing': return 11;
+                    case 'chargingAttack': return 12;
+                    default: return 0;
+                }
+            }
+            
+            getBreathingIntensity() {
+                // Breathing intensity based on character state
+                if (!this.character) return 1.0; // Default breathing intensity
+                
+                switch(this.character.state) {
+                    case 'running': return 2.0;
+                    case 'attacking': return 1.5;
+                    case 'rolling': return 1.8;
+                    case 'hurt': return 0.5;
+                    case 'dead': return 0.0;
+                    default: return 1.0;
+                }
             }
             
             initializeCharacterSystem() {
@@ -577,6 +653,7 @@
                     height: 40,
                     facing: 1,
                     color: template.color,
+                    isGrounded: true,
                     
                     // Stats (from template)
                     health: template.stats.health,


### PR DESCRIPTION
Implement mock `globalThis.wasmExports` and correct character property access to resolve runtime errors in `simple-player-demo.html`.

The `simple-player-demo.html` was intended as a WASM-first demo but used a basic mock `wasmEngine`. The `realistic-procedural-animator.js` expected a fully populated `globalThis.wasmExports` object, leading to runtime errors. This PR creates a comprehensive mock `wasmExports` to satisfy the animator's dependencies, along with fixing character property name mismatches (`velocity.x` vs `vx`) and adding a missing `isGrounded` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-daad25fd-ae08-41f4-b2d8-4e5eec77ad35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daad25fd-ae08-41f4-b2d8-4e5eec77ad35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

