### PR TITLE
Fix undefined calculateChecksum function

### DIFF
--- a/simple-player-demo.html
+++ b/simple-player-demo.html
@@ -478,7 +478,7 @@
                         this.wasmEngine.gameTime += dt;
                         this.wasmEngine.deltaTime = dt;
                         this.wasmEngine.frameNumber++;
-                        this.wasmEngine.checksum = this.calculateChecksum();
+                        this.wasmEngine.checksum = this.wasmEngine.calculateChecksum();
                     },
                     
                     calculateChecksum: () => {


### PR DESCRIPTION
Fix `TypeError: this.calculateChecksum is not a function` by correcting the scope reference to `this.wasmEngine.calculateChecksum()`.

The `calculateChecksum` function is a method of the `wasmEngine` object, but it was incorrectly called as `this.calculateChecksum()` within the `updateSimulation` function, where `this` did not refer to the `wasmEngine` instance. This change ensures the correct method is invoked.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1c536fc-0456-4256-965c-2f545237a6ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1c536fc-0456-4256-965c-2f545237a6ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

