### PR TITLE
feat: add network monitor cleanup

### DIFF
--- a/src/netcode/rollback-netcode.js
+++ b/src/netcode/rollback-netcode.js
@@ -88,6 +88,7 @@ class RollbackNetcode {
       bandwidth: 0,
       connectionQuality: 'unknown'
     }
+    this.networkMonitorId = null
     
     // WASM integration
     this.wasmIntegration = {
@@ -151,8 +152,9 @@ class RollbackNetcode {
     
     // Save initial state
     this.saveFrameState(0)
-    
+
     // Initialize network quality monitoring
+    this.stopNetworkMonitoring()
     this.startNetworkMonitoring()
     
     this.logger.info('Enhanced rollback netcode initialized', {
@@ -227,6 +229,7 @@ class RollbackNetcode {
    */
   stop() {
     this.running = false
+    this.stopNetworkMonitoring()
   }
   
   /**
@@ -899,9 +902,16 @@ class RollbackNetcode {
    * Start network quality monitoring
    */
   startNetworkMonitoring() {
-    setInterval(() => {
+    this.networkMonitorId = setInterval(() => {
       this.updateNetworkQuality()
     }, 5000) // Update every 5 seconds
+  }
+
+  stopNetworkMonitoring() {
+    if (this.networkMonitorId) {
+      clearInterval(this.networkMonitorId)
+      this.networkMonitorId = null
+    }
   }
   
   /**


### PR DESCRIPTION
## Summary
- track network monitoring interval and expose cleanup helper
- ensure network monitoring stops on shutdown or reinit

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b69b29bc83339644085fc0620765