### PR TITLE
feat: prefix game error logs

### DIFF
--- a/src/utils/game-error-handler.js
+++ b/src/utils/game-error-handler.js
@@ -8,7 +8,7 @@ import { createLogger } from './logger.js';
 
 export class GameErrorHandler {
   constructor() {
-    this.logger = createLogger('GameErrorHandler');
+    this.logger = createLogger({ prefix: 'GameErrorHandler' });
     
     // Error tracking and recovery state
     this.errorState = {


### PR DESCRIPTION
## Summary
- ensure game error handler logs are tagged with a dedicated prefix

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*
- `npm run lint` *(fails: 473 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b68fbbd48333b234daaf12e466de