### PR TITLE
Fix regex statefulness in InputValidator and add regression test

### DIFF
--- a/src/utils/input-validator.js
+++ b/src/utils/input-validator.js
@@ -39,7 +39,7 @@ export class InputValidator {
       /function\(/i,
       /<.*>/,
       /\$\{.*\}/,
-      /\.\.\//g
+      /\.\.\//
     ];
   }
 

--- a/test/unit/input-validator.test.js
+++ b/test/unit/input-validator.test.js
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { inputValidator } from '../../src/utils/input-validator.js';
+
+describe('InputValidator suspicious pattern detection', () => {
+  it('should consistently detect directory traversal attempts', () => {
+    expect(inputValidator.containsSuspiciousPattern('../')).to.be.true;
+    expect(inputValidator.containsSuspiciousPattern('../')).to.be.true;
+    expect(inputValidator.containsSuspiciousPattern('../')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- remove global flag from directory traversal regex to avoid stateful `test`
- add regression test to ensure suspicious pattern detection remains reliable

## Testing
- `npm test` *(fails: Cannot find package 'vitest', ReferenceError: describe is not defined)*
- `npm run test:unit`
- `npx mocha test/unit/input-validator.test.js`
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b69685a4833384462ca0c8cb7efb