### PR TITLE
feat: add main menu options

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,14 @@
         <button id="start-game-btn" disabled style="margin-top: 20px; padding: 12px 24px; background: #666; color: #fff; border: none; border-radius: 25px; font-size: 16px; cursor: not-allowed; transition: background 0.2s ease;">Loading...</button>
     </div>
 
+    <!-- Main Menu -->
+    <div id="main-menu" class="main-menu hidden">
+        <h1>DozedEnt</h1>
+        <button id="menu-new-game" class="menu-btn">New Game</button>
+        <button id="menu-continue" class="menu-btn">Continue</button>
+        <button id="menu-join-online" class="menu-btn">Join Online</button>
+    </div>
+
     <!-- Main Game Viewport -->
     <div id="viewport">
         <!-- Game Canvas for Enhanced Rendering -->

--- a/site.js
+++ b/site.js
@@ -469,15 +469,47 @@ class GameApplication {
     // Hide loading screen
     console.log('🔧 Hiding loading screen...');
     this.hideLoadingScreen();
-    
-    // On desktop, start the game directly
-    // On mobile, the orientation overlay will handle the game start
-    if (isDesktop) {
-      console.log('🖥️ Desktop detected - starting game directly');
-      this.startGame();
+
+    // Show main menu for mode selection
+    const mainMenu = document.getElementById('main-menu');
+    if (mainMenu) {
+      mainMenu.classList.remove('hidden');
+
+      const launch = () => {
+        if (isDesktop) {
+          console.log('🖥️ Desktop detected - starting game directly');
+          this.startGame();
+        } else {
+          console.log('📱 Mobile detected - checking orientation');
+          this.checkOrientationAndStart();
+        }
+      };
+
+      document.getElementById('menu-new-game')?.addEventListener('click', () => {
+        mainMenu.classList.add('hidden');
+        launch();
+      });
+
+      document.getElementById('menu-continue')?.addEventListener('click', () => {
+        mainMenu.classList.add('hidden');
+        launch();
+        this.gameStateManager?.showPersistenceUI('saves');
+      });
+
+      document.getElementById('menu-join-online')?.addEventListener('click', () => {
+        mainMenu.classList.add('hidden');
+        launch();
+        window.toggleLobby();
+      });
     } else {
-      console.log('📱 Mobile detected - checking orientation');
-      this.checkOrientationAndStart();
+      // Fallback: start game immediately
+      if (isDesktop) {
+        console.log('🖥️ Desktop detected - starting game directly');
+        this.startGame();
+      } else {
+        console.log('📱 Mobile detected - checking orientation');
+        this.checkOrientationAndStart();
+      }
     }
   }
 

--- a/src/css/ui.css
+++ b/src/css/ui.css
@@ -207,6 +207,45 @@
     color: #4a90e2;
 }
 
+/* Main Menu */
+.main-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 500;
+}
+
+.main-menu h1 {
+    color: #fff;
+    margin-bottom: 40px;
+    font-size: 48px;
+    letter-spacing: 2px;
+}
+
+.menu-btn {
+    width: 220px;
+    padding: 14px 0;
+    margin: 10px 0;
+    background: #4a90e2;
+    border: none;
+    border-radius: 8px;
+    color: #fff;
+    font-size: 18px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.menu-btn:hover {
+    background: #357abd;
+}
+
 /* Hidden class for dynamic show/hide */
 .hidden {
     display: none !important;


### PR DESCRIPTION
## Summary
- introduce a minimalist start menu with New Game, Continue, and Join Online options
- style start menu with modern translucent overlay and responsive buttons
- route start button to show menu and handle actions for launching, loading saves, or opening lobby

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bb4a49f88333bc7f236d113e2157