### PR TITLE
Setup emsdk for workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -36,6 +36,9 @@ jobs:
           
       - name: Install dependencies
         run: npm ci
+      
+      - name: Clone emsdk
+        run: git clone https://github.com/emscripten-core/emsdk.git
         
       - name: Build WASM module
         run: |


### PR DESCRIPTION
Add `emsdk` cloning step to the GitHub Pages deployment workflow to resolve 'No such file or directory' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf07afb8-ad5f-48a9-9071-7ad950e9ba31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf07afb8-ad5f-48a9-9071-7ad950e9ba31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

