### PR TITLE
Handle single-frame animation progress

### DIFF
--- a/src/animation/animation-system.js
+++ b/src/animation/animation-system.js
@@ -109,7 +109,7 @@ export class Animation {
     }
 
     getProgress() {
-        if (this.frames.length === 0) {return 0}
+        if (this.frames.length <= 1) {return 0}
         return this.currentFrame / (this.frames.length - 1)
     }
 

--- a/test/animation/single-frame-progress.test.js
+++ b/test/animation/single-frame-progress.test.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai'
+import { AnimationFrame, Animation } from '../../src/animation/animation-system.js'
+
+describe('Animation progress', () => {
+  it('returns finite progress for single-frame animations', () => {
+    const frame = new AnimationFrame(0, 0, 32, 32)
+    const anim = new Animation('single', [frame])
+
+    anim.play()
+    for (let i = 0; i < 10; i++) {
+      anim.update(16)
+    }
+
+    const progress = anim.getProgress()
+    expect(Number.isFinite(progress)).to.be.true
+    expect(progress).to.equal(0)
+  })
+})
+


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero by returning 0 progress for animations with one or fewer frames
- Add unit test ensuring single-frame animations report finite progress

## Testing
- `npm run test:unit`
- `npx mocha "test/animation/**/*.test.js"`
- `npm run lint` *(fails: 'no-unused-vars', 'Parsing error: Expecting Unicode escape sequence \uXXXX')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c4ab49cc8333b671fbe2d86ba477