### PR TITLE
Replace setTimeout with frame timers

### DIFF
--- a/docs/js/src/animation/animation-system.js
+++ b/docs/js/src/animation/animation-system.js
@@ -819,6 +819,17 @@ export class CharacterAnimator {
         
         this.targetBlendFactors = { ...this.blendFactors }
         this.blendSpeed = 0.2
+
+        // Internal timers for temporary states
+        this.hurtTimer = 0
+        this.attackTimer = 0
+        this.rollTimer = 0
+    }
+
+    resetActionTimers() {
+        this.hurtTimer = 0
+        this.attackTimer = 0
+        this.rollTimer = 0
     }
 
     // Helper function to convert numeric WASM state to string for internal use
@@ -843,7 +854,8 @@ export class CharacterAnimator {
 
     setAnimState(newState) {
         if (this.state === newState) {return}
-        
+        this.resetActionTimers()
+
         this.state = newState
         this.stateName = this.getAnimStateName(newState)
         
@@ -894,6 +906,26 @@ export class CharacterAnimator {
     }
 
     update(deltaTime, position, velocity = { x: 0, y: 0 }, isGrounded = true) {
+        // Update state timers
+        if (this.hurtTimer > 0) {
+            this.hurtTimer -= deltaTime
+            if (this.hurtTimer <= 0 && this.state === 5) {
+                this.setAnimState(0) // Idle
+            }
+        }
+        if (this.attackTimer > 0) {
+            this.attackTimer -= deltaTime
+            if (this.attackTimer <= 0 && this.state === 2) {
+                this.setAnimState(0) // Idle
+            }
+        }
+        if (this.rollTimer > 0) {
+            this.rollTimer -= deltaTime
+            if (this.rollTimer <= 0 && this.state === 4) {
+                this.setAnimState(0) // Idle
+            }
+        }
+
         // Update animation controller
         this.controller.update(deltaTime)
 
@@ -977,29 +1009,17 @@ export class CharacterAnimator {
 
     triggerHurt() {
         this.setAnimState(5) // Hurt
-        setTimeout(() => {
-            if (this.state === 5) { // Hurt
-                this.setAnimState(0) // Idle
-            }
-        }, 300)
+        this.hurtTimer = 300
     }
 
     triggerAttack() {
         this.setAnimState(2) // Attack
-        setTimeout(() => {
-            if (this.state === 2) { // Attack
-                this.setAnimState(0) // Idle
-            }
-        }, 400)
+        this.attackTimer = 400
     }
 
     triggerRoll() {
         this.setAnimState(4) // Roll
-        setTimeout(() => {
-            if (this.state === 4) { // Roll
-                this.setAnimState(0) // Idle
-            }
-        }, 400)
+        this.rollTimer = 400
     }
 
     triggerBlock() {

--- a/src/animation/animation-system.js
+++ b/src/animation/animation-system.js
@@ -816,6 +816,17 @@ export class CharacterAnimator {
         
         this.targetBlendFactors = { ...this.blendFactors }
         this.blendSpeed = 0.2
+
+        // Internal timers for temporary states
+        this.hurtTimer = 0
+        this.attackTimer = 0
+        this.rollTimer = 0
+    }
+
+    resetActionTimers() {
+        this.hurtTimer = 0
+        this.attackTimer = 0
+        this.rollTimer = 0
     }
 
     // Helper function to convert numeric WASM state to string for internal use
@@ -840,7 +851,8 @@ export class CharacterAnimator {
 
     setAnimState(newState) {
         if (this.state === newState) {return}
-        
+        this.resetActionTimers()
+
         this.state = newState
         this.stateName = this.getAnimStateName(newState)
         
@@ -891,6 +903,26 @@ export class CharacterAnimator {
     }
 
     update(deltaTime, position, velocity = { x: 0, y: 0 }, isGrounded = true) {
+        // Update state timers
+        if (this.hurtTimer > 0) {
+            this.hurtTimer -= deltaTime
+            if (this.hurtTimer <= 0 && this.state === 5) {
+                this.setAnimState(0) // Idle
+            }
+        }
+        if (this.attackTimer > 0) {
+            this.attackTimer -= deltaTime
+            if (this.attackTimer <= 0 && this.state === 2) {
+                this.setAnimState(0) // Idle
+            }
+        }
+        if (this.rollTimer > 0) {
+            this.rollTimer -= deltaTime
+            if (this.rollTimer <= 0 && this.state === 4) {
+                this.setAnimState(0) // Idle
+            }
+        }
+
         // Update animation controller
         this.controller.update(deltaTime)
 
@@ -974,29 +1006,17 @@ export class CharacterAnimator {
 
     triggerHurt() {
         this.setAnimState(5) // Hurt
-        setTimeout(() => {
-            if (this.state === 5) { // Hurt
-                this.setAnimState(0) // Idle
-            }
-        }, 300)
+        this.hurtTimer = 300
     }
 
     triggerAttack() {
         this.setAnimState(2) // Attack
-        setTimeout(() => {
-            if (this.state === 2) { // Attack
-                this.setAnimState(0) // Idle
-            }
-        }, 400)
+        this.attackTimer = 400
     }
 
     triggerRoll() {
         this.setAnimState(4) // Roll
-        setTimeout(() => {
-            if (this.state === 4) { // Roll
-                this.setAnimState(0) // Idle
-            }
-        }, 400)
+        this.rollTimer = 400
     }
 
     triggerBlock() {


### PR DESCRIPTION
## Summary
- replace asynchronous setTimeout calls in character animation triggers with internal frame timers
- reset action timers when state changes to prevent overlapping animations

## Testing
- `npm test` *(fails: Cannot find package 'vitest'; describe is not defined)*
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4c46e7c8333b655ceeac9b958be