### PR TITLE
Replace Date.now with elapsed time accumulators

### DIFF
--- a/src/animation/animation-system.js
+++ b/src/animation/animation-system.js
@@ -816,6 +816,9 @@ export class CharacterAnimator {
         
         this.targetBlendFactors = { ...this.blendFactors }
         this.blendSpeed = 0.2
+
+        // Time accumulator for deterministic animations
+        this.elapsedTime = 0
     }
 
     // Helper function to convert numeric WASM state to string for internal use
@@ -891,6 +894,9 @@ export class CharacterAnimator {
     }
 
     update(deltaTime, position, velocity = { x: 0, y: 0 }, isGrounded = true) {
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000
+
         // Update animation controller
         this.controller.update(deltaTime)
 
@@ -942,7 +948,7 @@ export class CharacterAnimator {
         // Apply momentum-based adjustments
         transform.rotation += momentumData.leanAngle
         transform.scaleY *= (1 + momentumData.stretchFactor)
-        transform.offsetY += momentumData.bounceFactor * Math.sin(Date.now() * 0.01)
+        transform.offsetY += momentumData.bounceFactor * Math.sin(this.elapsedTime * 0.01)
 
         // Apply squash/stretch
         transform.scaleX *= squashStretch.scaleX

--- a/src/animation/enhanced-wolf-body.js
+++ b/src/animation/enhanced-wolf-body.js
@@ -57,6 +57,9 @@ export class EnhancedWolfBody {
             }
         }
 
+        // Time accumulator for deterministic animations
+        this.elapsedTime = 0
+
         // Body part definitions with detailed anatomy
         this.bodyParts = {
             head: {
@@ -275,6 +278,9 @@ export class EnhancedWolfBody {
 
     // Update body animation state
     update(deltaTime, wolf) {
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000
+
         this.updateBreathing(deltaTime, wolf)
         this.updateMuscleTension(deltaTime, wolf)
         this.updateFurDynamics(deltaTime, wolf)
@@ -286,7 +292,7 @@ export class EnhancedWolfBody {
         const breathRate = wolf.state === 'running' ? 0.008 : 0.003
         const breathAmplitude = wolf.state === 'running' ? 0.04 : 0.02
 
-        this.animationState.breathing = Math.sin(Date.now() * breathRate) * breathAmplitude
+        this.animationState.breathing = Math.sin(this.elapsedTime * breathRate) * breathAmplitude
     }
 
     // Update muscle tension based on activity
@@ -323,7 +329,7 @@ export class EnhancedWolfBody {
     updateFurDynamics(deltaTime, wolf) {
         // Fur flow based on movement and wind
         // Calculate movement speed for fur dynamics
-        const windEffect = { x: Math.sin(Date.now() * 0.001) * 0.1, y: 0 }
+        const windEffect = { x: Math.sin(this.elapsedTime * 0.001) * 0.1, y: 0 }
 
         this.animationState.furFlow.x = -wolf.velocity.x * 0.001 + windEffect.x
         this.animationState.furFlow.y = -wolf.velocity.y * 0.001 + windEffect.y
@@ -421,7 +427,7 @@ export class EnhancedWolfBody {
             this.renderFurStrands(ctx, -width/2, 0, width, length, i)
 
             // Update for next segment
-            const segmentAngle = Math.sin(Date.now() * 0.003 + i * 0.5) * 0.2
+            const segmentAngle = Math.sin(this.elapsedTime * 0.003 + i * 0.5) * 0.2
             currentX += Math.cos(segmentAngle) * length
             currentY += Math.sin(segmentAngle) * length
             currentAngle += segmentAngle

--- a/src/animation/enhanced-wolf-integration.js
+++ b/src/animation/enhanced-wolf-integration.js
@@ -28,6 +28,9 @@ export class EnhancedWolfIntegration {
             furStrandCount: 0,
             activeWolves: 0
         }
+
+        // Time accumulator for deterministic animations
+        this.elapsedTime = 0
     }
 
     // Initialize all systems
@@ -62,6 +65,7 @@ export class EnhancedWolfIntegration {
         const baseWolf = new EnhancedWolfCharacter(x, y, wolfOptions)
 
         // Generate body variation profile
+        this.variationSystem.elapsedTime = this.elapsedTime
         const variationProfile = this.variationSystem.generateBodyVariation(
             wolfOptions.type,
             wolfOptions.environment,
@@ -193,6 +197,10 @@ export class EnhancedWolfIntegration {
     // Update all enhanced wolves
     update(deltaTime, player) {
         if (!this.systemsInitialized) {return}
+
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000
+        this.variationSystem.elapsedTime = this.elapsedTime
 
         const startTime = performance.now()
         let activeWolves = 0
@@ -380,7 +388,7 @@ export class EnhancedWolfIntegration {
         ctx.save()
 
         const auraRadius = wolf.width * 0.8
-        const auraAlpha = 0.3 + Math.sin(Date.now() * 0.003) * 0.1
+        const auraAlpha = 0.3 + Math.sin(this.elapsedTime * 0.003) * 0.1
 
         // Outer glow
         const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, auraRadius)
@@ -735,7 +743,7 @@ export class EnhancedWolfIntegration {
 
         return {
             version: '1.0',
-            timestamp: Date.now(),
+            timestamp: this.elapsedTime,
             wolfStates,
             performanceMetrics: this.performanceMetrics
         }

--- a/src/animation/player-animator.js
+++ b/src/animation/player-animator.js
@@ -38,6 +38,9 @@ export class AnimatedPlayer {
         this.chargeTime = 0 // Will be WASM-driven or removed
         this.maxChargeTime = 1.5 // Will be WASM-driven or removed
 
+        // Time accumulator for deterministic animations
+        this.elapsedTime = 0
+
         // Deterministic animation/event parameters - these are mostly cues for animation
         this.params = {
             roll: {
@@ -161,6 +164,8 @@ export class AnimatedPlayer {
     }
     
     update(deltaTime, input = {}) {
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000
         // Update timers - WASM manages core game timers
         this._prevNormTime = this.getNormalizedTime()
         this.attackCooldown = Math.max(0, this.attackCooldown - deltaTime)
@@ -646,7 +651,7 @@ export class AnimatedPlayer {
         
         // Apply invulnerability flashing - this will be driven by WASM
         if (globalThis.wasmExports?.get_is_invulnerable?.() === 1) { // Assuming a WASM export for invulnerability
-            ctx.globalAlpha = 0.5 + Math.sin(Date.now() * 0.02) * 0.3
+            ctx.globalAlpha = 0.5 + Math.sin(this.elapsedTime * 0.02) * 0.3
         }
         
         // Get current animation frame

--- a/src/animation/realistic-procedural-animator.js
+++ b/src/animation/realistic-procedural-animator.js
@@ -76,6 +76,9 @@ export class RealisticProceduralAnimator {
         this.frameCount = 0;
         this.lastUpdate = 0;
         this.cachedTransforms = new Map();
+
+        // Time accumulator for deterministic animations
+        this.elapsedTime = 0;
         
         // Environmental response
         this.environmentalResponses = new EnvironmentalResponseSystem();
@@ -84,6 +87,9 @@ export class RealisticProceduralAnimator {
     update(deltaTime, wasmData = {}) {
         this.frameCount++;
         const now = performance.now();
+
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000;
         
         // Performance throttling
         if (this.config.enableOptimizations && (now - this.lastUpdate) < (1000 / this.config.updateRate)) {
@@ -278,7 +284,7 @@ export class RealisticProceduralAnimator {
         targetY += wasmData.momentumY * 0.2;
         
         // Add some natural variation based on breathing
-        targetY += Math.sin(Date.now() * 0.001 * wasmData.breathingIntensity) * 0.5;
+        targetY += Math.sin(this.elapsedTime * 0.001 * wasmData.breathingIntensity) * 0.5;
         
         return { x: targetX, y: targetY };
     }

--- a/src/animation/wolf-body-physics.js
+++ b/src/animation/wolf-body-physics.js
@@ -105,6 +105,9 @@ export class WolfBodyPhysics {
 
         // Collision system
         this.collisionSystem = new WolfCollisionSystem()
+
+        // Time accumulator for deterministic physics
+        this.elapsedTime = 0
     }
 
     // Initialize physics for a wolf
@@ -119,7 +122,7 @@ export class WolfBodyPhysics {
             angularVelocity: 0,
             isGrounded: true,
             groundContactPoints: [],
-            lastUpdateTime: Date.now()
+            lastUpdateTime: this.elapsedTime
         }
 
         // Initialize body segments
@@ -286,6 +289,10 @@ export class WolfBodyPhysics {
     update(deltaTime, wolf, environment = {}) {
         const physicsState = this.physicsStates.get(wolf.id)
         if (!physicsState) {return}
+
+        // Accumulate elapsed time in milliseconds
+        this.elapsedTime += deltaTime * 1000
+        physicsState.lastUpdateTime = this.elapsedTime
 
         const dt = Math.min(deltaTime, 1/60) // Cap at 60fps for stability
 

--- a/src/animation/wolf-body-variations.js
+++ b/src/animation/wolf-body-variations.js
@@ -105,6 +105,9 @@ export class WolfBodyVariations {
 
         // Individual variation seed (deterministic if available)
         this.seed = Number((globalThis.runSeedForVisuals ?? 1n) % 10000n)
+
+        // Time accumulator synced externally
+        this.elapsedTime = 0
     }
 
     // Generate complete body variation for a wolf
@@ -430,7 +433,7 @@ export class WolfBodyVariations {
             // Metadata
             archetype: variation.baseProfile.archetype,
             seed: this.seed,
-            generated: Date.now()
+            generated: this.elapsedTime
         }
 
         // Apply environmental modifiers
@@ -530,7 +533,7 @@ export class WolfBodyVariations {
         return {
             ...variation,
             exportFormat: 'WolfBodyVariations_v1.0',
-            exportedAt: Date.now()
+            exportedAt: this.elapsedTime
         }
     }
 


### PR DESCRIPTION
## Summary
- replace `Date.now()` timing with deterministic `elapsedTime` accumulators across animation modules
- use accumulated time in rendering effects and metadata, avoiding wall‑clock dependence

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*
- `npm run build:animations`


------
https://chatgpt.com/codex/tasks/task_e_68c5c52f68b083339a61780424d8c684