### PR TITLE
fix script path and wolf vocalization include

### DIFF
--- a/src/wasm/enemies.h
+++ b/src/wasm/enemies.h
@@ -3,7 +3,6 @@
 
 #include "internal_core.h"
 #include "wolf_anim_data.h"
-#include "wolf_vocalization.h"
 #include "alpha_wolf.h"
 #include "scent_tracking.h"
 
@@ -257,6 +256,8 @@ static float g_pack_last_failure_time = -1000.f;
 static int g_pack_successful_hunts = 0;
 static int g_pack_failed_hunts = 0;
 static float g_player_skill_estimate = 0.5f; // 0-1, pack's estimate of player skill
+
+#include "wolf_vocalization.h" // Requires enemy and pack definitions
 
 // Wolf pack management system - maintain 3 active packs
 #define MAX_WOLF_PACKS 3

--- a/src/wasm/wolf_vocalization.h
+++ b/src/wasm/wolf_vocalization.h
@@ -2,7 +2,7 @@
 // Implements howls, growls, barks for pack communication
 #pragma once
 
-#include "enemies.h"
+#include "enemies.h" // Access enemy structs and pack data
 
 // Vocalization types for wolves
 enum class VocalizationType : unsigned char {

--- a/tools/scripts/build-wasm.ps1
+++ b/tools/scripts/build-wasm.ps1
@@ -37,7 +37,7 @@ Remove-Item -Path "*.wasm" -Force -ErrorAction SilentlyContinue
 # Generate balance header from data files
 Write-Host "Generating balance data header..." -ForegroundColor Yellow
 try {
-    node .\tools\scripts\generate-balance.cjs | Write-Host
+    node ./tools/scripts/generate-balance.cjs | Write-Host
     Write-Host "Balance data generated" -ForegroundColor Green
 } catch {
     Write-Host "Balance generation failed: $_" -ForegroundColor Red


### PR DESCRIPTION
## Summary
- use POSIX path for balance generator in wasm build script
- include wolf_vocalization after enemy definitions to expose constants
- clarify enemy include in wolf_vocalization header

## Testing
- `node tools/scripts/generate-balance.cjs`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68c68d9a50f08333ab382c00551a60f4