### PR TITLE
Update PowerShell setup action in workflows

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm ci
         
       - name: Install PowerShell
-        uses: actions/setup-pwsh@v2
+        uses: pwsh/setup-pwsh@v2
       
       - name: Build project and prepare docs
         run: npm run build:docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Install PowerShell
-        uses: actions/setup-pwsh@v2
+        uses: pwsh/setup-pwsh@v2
         
       - name: Build docs
         run: npm run build:docs

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
         
       - name: Install PowerShell
-        uses: actions/setup-pwsh@v2
+        uses: pwsh/setup-pwsh@v2
         
       - name: Run linter
         run: npm run lint || true
@@ -83,7 +83,7 @@ jobs:
         run: npm ci
         
       - name: Install PowerShell
-        uses: actions/setup-pwsh@v2
+        uses: pwsh/setup-pwsh@v2
         
       - name: Build project and prepare docs
         run: bash ./deploy.sh


### PR DESCRIPTION
## Summary
- use pwsh/setup-pwsh@v2 to install PowerShell in deploy workflow
- update test-and-deploy workflow to use pwsh/setup-pwsh@v2
- switch gh-pages deployment workflow to pwsh/setup-pwsh@v2

## Testing
- `npm run lint` (fails: 209 errors)
- `npm test` (fails: ReferenceError: describe is not defined)
- `act` (unable to install: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_68c696a012c48333a6af055f30c58597