### PR TITLE
Fix incorrect powershell setup action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Install PowerShell
-        uses: pwsh/setup-pwsh@v2
+        uses: actions/setup-pwsh@v2
         
       - name: Build docs
         run: npm run build:docs


### PR DESCRIPTION
Update GitHub Actions workflow to use `actions/setup-pwsh` to resolve the 'repository not found' error.

The `pwsh/setup-pwsh` action was incorrect; `actions/setup-pwsh` is the official and valid action for setting up PowerShell.

---
<a href="https://cursor.com/background-agent?bcId=bc-844d5002-47db-4870-a8a8-bf178311c2c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-844d5002-47db-4870-a8a8-bf178311c2c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

