### PR TITLE
Fix batched WASM player state sync

### DIFF
--- a/src/game/game-state-manager.js
+++ b/src/game/game-state-manager.js
@@ -231,10 +231,24 @@ export class GameStateManager {
 
     // Get all state in one batched call
     const playerState = this.wasmManager.getPlayerState();
-    
-    // Update player state
-    this.playerState.x = playerState.x;
-    this.playerState.y = playerState.y;
+    if (!playerState || typeof playerState !== 'object') {
+      console.warn('Invalid player state received from WASM:', playerState);
+      return;
+    }
+
+    const safeX = Number.isFinite(playerState.x) ? playerState.x : 0;
+    const safeY = Number.isFinite(playerState.y) ? playerState.y : 0;
+
+    // Update player state (preserve both normalized and legacy nested structure)
+    this.playerState.x = safeX;
+    this.playerState.y = safeY;
+    if (!this.playerState.position) {
+      this.playerState.position = { x: safeX, y: safeY };
+    } else {
+      this.playerState.position.x = safeX;
+      this.playerState.position.y = safeY;
+    }
+
     this.playerState.stamina = playerState.stamina;
     this.playerState.health = playerState.health;
     this.playerState.gold = playerState.gold;
@@ -244,11 +258,16 @@ export class GameStateManager {
     this.playerState.isRolling = Boolean(playerState.isRolling);
     this.playerState.isBlocking = Boolean(playerState.isBlocking);
     this.playerState.animState = playerState.animState;
-    
-    // Update game phase
-    this.currentPhase = playerState.phase;
-    
+
+    // Update game phase (maintain compatibility with legacy property)
+    const safePhase = Number.isFinite(playerState.phase) ? playerState.phase : this.phaseState.currentPhase;
+    this.phaseState.currentPhase = safePhase;
+    this.currentPhase = safePhase;
+
     // Update camera to follow player
+    this.cameraState.targetPosition.x = safeX;
+    this.cameraState.targetPosition.y = safeY;
+
     this.updateCameraState();
   }
 

--- a/test/unit/game-state-manager.test.js
+++ b/test/unit/game-state-manager.test.js
@@ -299,9 +299,38 @@ describe('GameStateManager', () => {
 
     it('should update camera state', () => {
       gameStateManager.updateCameraState();
-      
+
       // Camera state should be updated based on player position
       expect(gameStateManager.cameraState.targetPosition).to.deep.equal({ x: 0.5, y: 0.5 });
+    });
+
+    it('should synchronize position and phase from batched WASM state', () => {
+      mockWasmManager.isLoaded = true;
+      mockWasmManager.getPlayerState.returns({
+        x: 0.65,
+        y: 0.35,
+        stamina: 75,
+        health: 0.8,
+        gold: 12,
+        essence: 3,
+        velX: 1,
+        velY: -0.5,
+        isRolling: 1,
+        isBlocking: 0,
+        animState: 2,
+        phase: 3
+      });
+
+      gameStateManager.updateStateFromWasm();
+
+      expect(gameStateManager.playerState.x).to.equal(0.65);
+      expect(gameStateManager.playerState.y).to.equal(0.35);
+      expect(gameStateManager.playerState.position).to.deep.equal({ x: 0.65, y: 0.35 });
+      expect(gameStateManager.phaseState.currentPhase).to.equal(3);
+      expect(gameStateManager.currentPhase).to.equal(3);
+      expect(gameStateManager.cameraState.targetPosition).to.deep.equal({ x: 0.65, y: 0.35 });
+      expect(gameStateManager.playerState.isRolling).to.be.true;
+      expect(gameStateManager.playerState.isBlocking).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary
- ensure the batched WASM state update keeps the legacy player.position structure in sync and updates the current phase
- mirror the same fixes in the docs build so both bundles agree
- add a unit test that exercises the batched update path and asserts player, phase, and camera data are synchronized

## Testing
- npx mocha test/unit/game-state-manager.test.js --grep "synchronize position"


------
https://chatgpt.com/codex/tasks/task_e_68c90f217a9883339342107a1dac5152