### PR TITLE
Fix utils exports and add persistent player identity

### DIFF
--- a/docs/js/src/lobby/room-manager.js
+++ b/docs/js/src/lobby/room-manager.js
@@ -5,11 +5,16 @@
 
 import { idGenerator } from '../utils/deterministic-id-generator.js'
 
+const PLAYER_ID_STORAGE_KEY = 'dozedent.lobby.playerId'
+const PLAYER_NAME_STORAGE_KEY = 'dozedent.lobby.playerName'
+const MAX_PLAYER_NAME_LENGTH = 24
+
 export class RoomManager {
   constructor() {
     this.currentRoom = null;
     this.rooms = new Map();
     this.eventListeners = new Map();
+    this.localPlayer = this.loadStoredPlayerIdentity();
   }
 
   /**
@@ -18,13 +23,22 @@ export class RoomManager {
    * @returns {Promise<Object>} Created room object
    */
   createRoom(options = {}) {
+    const {
+      playerName,
+      playerId,
+      ...roomOptions
+    } = options;
+
     const roomConfig = {
-      name: options.name || 'New Room',
-      type: options.type || 'public',
-      gameMode: options.gameMode || 'default',
-      maxPlayers: options.maxPlayers || 4,
-      allowSpectators: options.allowSpectators !== false,
-      ...options
+      name: roomOptions.name ?? 'New Room',
+      type: roomOptions.type ?? 'public',
+      gameMode: roomOptions.gameMode ?? 'default',
+      maxPlayers: roomOptions.maxPlayers ?? 4,
+      allowSpectators:
+        roomOptions.allowSpectators !== undefined
+          ? roomOptions.allowSpectators
+          : true,
+      ...roomOptions
     };
 
     try {
@@ -43,7 +57,9 @@ export class RoomManager {
 
       this.rooms.set(roomId, room);
       this.currentRoom = room;
-      
+
+      this.ensurePlayerIdentity({ playerName, playerId });
+
       this.emit('roomCreated', room);
       console.log('Room created:', room);
       
@@ -66,29 +82,43 @@ export class RoomManager {
    * @param {string} roomId - Room ID to join
    * @returns {Promise<Object>} Room object
    */
-  joinRoom(roomId) {
+  joinRoom(roomId, options = {}) {
     try {
       const room = this.rooms.get(roomId);
-      
+
       if (!room) {
         throw new Error('Room not found. The room may have been deleted or the ID is incorrect.');
       }
 
-      if (room.players.length >= room.maxPlayers) {
+      const identity = this.ensurePlayerIdentity({
+        playerName: options.playerName,
+        playerId: options.playerId
+      });
+
+      let player = room.players.find(existing => existing.id === identity.id);
+
+      if (!player && room.players.length >= room.maxPlayers) {
         throw new Error('Room is full. Please try joining a different room.');
       }
 
-      // Add current player to room
-      const player = {
-        id: this.generatePlayerId(),
-        name: this.getPlayerName(),
-        isReady: false,
-        joinedAt: Date.now()
-      };
-
-      room.players.push(player);
+      if (!player) {
+        player = {
+          id: identity.id,
+          name: identity.name,
+          isReady: false,
+          joinedAt: Date.now(),
+          metadata: options.metadata ?? null
+        };
+        room.players.push(player);
+      } else {
+        player.name = identity.name;
+        if (options.metadata !== undefined) {
+          player.metadata = options.metadata;
+        }
+        player.lastJoinedAt = Date.now();
+      }
       this.currentRoom = room;
-      
+
       this.emit('roomJoined', room);
       console.log('Joined room:', room);
       
@@ -143,15 +173,22 @@ export class RoomManager {
       
       if (availableRooms.length > 0) {
         // Join first available room
-        return await this.joinRoom(availableRooms[0].id);
-      } 
-        // Create new room
-        return await this.createRoom({
-          name: 'Quick Play Room',
-          gameMode: options.gameMode || 'default',
-          maxPlayers: options.maxPlayers || 4
-        });
-      
+        return await this.joinRoom(availableRooms[0].id, options);
+      }
+      // Create and join a new room when none are available
+      const room = await this.createRoom({
+        name: 'Quick Play Room',
+        gameMode: options.gameMode ?? 'default',
+        maxPlayers: options.maxPlayers ?? 4,
+        type: options.type,
+        allowSpectators: options.allowSpectators,
+        playerName: options.playerName,
+        playerId: options.playerId
+      });
+
+      await this.joinRoom(room.id, options);
+      return room;
+
     } catch (error) {
       console.error('Quick play failed:', error);
       throw new Error(`Quick play failed: ${error.message}`);
@@ -260,17 +297,15 @@ export class RoomManager {
    * @returns {string} Player ID
    */
   getCurrentPlayerId() {
-    // This should be replaced with actual player ID from authentication
-    return 'current-player';
+    return this.ensurePlayerIdentity().id;
   }
 
   /**
-   * Get player name (placeholder implementation)
+   * Get player name from local identity state
    * @returns {string} Player name
    */
   getPlayerName() {
-    // This should be replaced with actual player name from authentication
-    return 'Player';
+    return this.ensurePlayerIdentity().name;
   }
 
   /**
@@ -316,6 +351,114 @@ export class RoomManager {
         }
       });
     }
+  }
+
+  /**
+   * Load stored player identity from persistent storage
+   * @returns {{id: string|null, name: string|null}}
+   */
+  loadStoredPlayerIdentity() {
+    if (typeof localStorage === 'undefined') {
+      return { id: null, name: null };
+    }
+
+    try {
+      return {
+        id: localStorage.getItem(PLAYER_ID_STORAGE_KEY),
+        name: localStorage.getItem(PLAYER_NAME_STORAGE_KEY)
+      };
+    } catch (error) {
+      console.warn('Unable to access player identity storage:', error);
+      return { id: null, name: null };
+    }
+  }
+
+  /**
+   * Persist player identity details if storage is available
+   * @param {{id: string, name: string}} identity - Identity to persist
+   */
+  persistPlayerIdentity(identity) {
+    if (typeof localStorage === 'undefined') {return;}
+
+    try {
+      if (identity.id) {
+        localStorage.setItem(PLAYER_ID_STORAGE_KEY, identity.id);
+      }
+      if (identity.name) {
+        localStorage.setItem(PLAYER_NAME_STORAGE_KEY, identity.name);
+      }
+    } catch (error) {
+      console.warn('Unable to persist player identity:', error);
+    }
+  }
+
+  /**
+   * Normalize player names and clamp to maximum length
+   * @param {string} name - Requested player name
+   * @returns {string} Normalized name or empty string when invalid
+   */
+  normalizePlayerName(name) {
+    if (name === null || name === undefined) {return '';}
+
+    const normalized = String(name).trim().replace(/\s+/g, ' ');
+    if (!normalized) {return '';}
+
+    return normalized.slice(0, MAX_PLAYER_NAME_LENGTH);
+  }
+
+  /**
+   * Generate a friendly fallback player name based on the current ID
+   * @param {string} id - Player identifier
+   * @returns {string} Generated player name
+   */
+  generateDefaultPlayerName(id) {
+    const cleanedId = (id || '').replace(/[^a-zA-Z0-9]/g, '');
+    const suffix = cleanedId.slice(-4).toUpperCase();
+
+    if (suffix) {
+      return `Player ${suffix}`;
+    }
+
+    const fallback = idGenerator.randomString(4, false).toUpperCase();
+    return `Player ${fallback}`;
+  }
+
+  /**
+   * Ensure the local player identity is populated and up to date
+   * @param {{playerName?: string, playerId?: string}} overrides - Overrides for identity
+   * @returns {{id: string, name: string}} Player identity
+   */
+  ensurePlayerIdentity(overrides = {}) {
+    const stored = this.localPlayer ?? this.loadStoredPlayerIdentity();
+    const identity = {
+      id: stored?.id ?? null,
+      name: stored?.name ?? null
+    };
+
+    if (typeof overrides.playerId === 'string') {
+      const trimmedId = overrides.playerId.trim();
+      if (trimmedId) {
+        identity.id = trimmedId;
+      }
+    }
+
+    const normalizedName = this.normalizePlayerName(overrides.playerName);
+    if (normalizedName) {
+      identity.name = normalizedName;
+    }
+
+    if (!identity.id) {
+      identity.id = this.generatePlayerId();
+    }
+
+    if (!identity.name) {
+      identity.name = this.generateDefaultPlayerName(identity.id);
+    }
+
+    this.localPlayer = identity;
+    this.persistPlayerIdentity(identity);
+
+    return identity;
   }
 
   /**

--- a/docs/js/src/utils/index.d.ts
+++ b/docs/js/src/utils/index.d.ts
@@ -125,14 +125,14 @@ declare module 'trystero' {
   export const selfId: string
   
   // Room Manager exports
-  export {default as RoomManager} from './room-manager'
-  export {default as HostAuthority} from './host-authority'
-  export {default as RoomLobbyUI} from './room-lobby-ui'
+  export {default as RoomManager} from '../netcode/room-manager'
+  export {default as HostAuthority} from '../netcode/host-authority'
+  export {default as RoomLobbyUI} from '../netcode/room-lobby-ui'
   
   // Rollback Netcode exports
-  export {default as RollbackNetcode} from './rollback-netcode'
-  export {default as RollbackP2P} from './rollback-p2p'
-  export {RollbackLobby, HOSTING_MODE} from './rollback-lobby'
+  export {default as RollbackNetcode} from '../netcode/rollback-netcode'
+  export {default as RollbackP2P} from '../netcode/rollback-p2p'
+  export {RollbackLobby, HOSTING_MODE} from '../netcode/rollback-lobby'
   export {
     DeterministicGame,
     DeterministicRandom,
@@ -145,5 +145,5 @@ declare module 'trystero' {
     fixedSqrt,
     fixedSin,
     fixedCos
-  } from './deterministic-game'
+  } from '../netcode/deterministic-game'
 }

--- a/docs/js/src/utils/index.js
+++ b/docs/js/src/utils/index.js
@@ -1,7 +1,7 @@
-export {getRelaySockets, joinRoom, selfId} from './nostr.js'
+export {getRelaySockets, joinRoom, selfId} from '../netcode/nostr.js'
 export {default as RoomManager} from './room-manager.js'
-export {default as HostAuthority} from './host-authority.js'
-export {default as RoomLobbyUI} from './room-lobby-ui.js'
+export {default as HostAuthority} from '../host-authority.js'
+export {default as RoomLobbyUI} from '../netcode/room-lobby-ui.js'
 
 // Visual & Animation Features
 export {
@@ -12,7 +12,7 @@ export {
   CharacterAnimator,
   AnimationPresets,
   default as AnimationSystem
-} from './animation-system.js'
+} from '../animation/animation-system.js'
 export {default as CameraEffects} from './camera-effects.js'
 export {
   Particle,
@@ -37,16 +37,16 @@ export {
 export {
   EnhancedLobbyUI,
   default as EnhancedLobbyUIDefault
-} from './enhanced-lobby-ui.js'
+} from '../netcode/enhanced-lobby-ui.js'
 export {
   LobbyAnalytics,
   default as LobbyAnalyticsDefault
-} from './utils/lobby-analytics.js'
+} from './lobby-analytics.js'
 
 // Rollback Netcode exports
-export {default as RollbackNetcode} from './rollback-netcode.js'
-export {default as RollbackP2P} from './rollback-p2p.js'
-export {RollbackLobby, HOSTING_MODE} from './rollback-lobby.js'
+export {default as RollbackNetcode} from '../netcode/rollback-netcode.js'
+export {default as RollbackP2P} from '../netcode/rollback-p2p.js'
+export {RollbackLobby, HOSTING_MODE} from '../netcode/rollback-lobby.js'
 export {
   DeterministicGame,
   DeterministicRandom,
@@ -59,4 +59,4 @@ export {
   fixedSqrt,
   fixedSin,
   fixedCos
-} from './deterministic-game.js'
+} from '../netcode/deterministic-game.js'

--- a/docs/js/src/utils/room-manager.js
+++ b/docs/js/src/utils/room-manager.js
@@ -3,7 +3,7 @@
  * Handles room creation, listing, joining, and authority management
  */
 
-import { joinRoom as joinNostrRoom, selfId } from './nostr.js'
+import { joinRoom as joinNostrRoom, selfId } from '../netcode/nostr.js'
 import { toJson, fromJson, genId } from './utils.js'
 
 const ROOM_ANNOUNCE_INTERVAL = 5000 // 5 seconds

--- a/src/lobby/room-manager.js
+++ b/src/lobby/room-manager.js
@@ -5,11 +5,16 @@
 
 import { idGenerator } from '../utils/deterministic-id-generator.js'
 
+const PLAYER_ID_STORAGE_KEY = 'dozedent.lobby.playerId'
+const PLAYER_NAME_STORAGE_KEY = 'dozedent.lobby.playerName'
+const MAX_PLAYER_NAME_LENGTH = 24
+
 export class RoomManager {
   constructor() {
     this.currentRoom = null;
     this.rooms = new Map();
     this.eventListeners = new Map();
+    this.localPlayer = this.loadStoredPlayerIdentity();
   }
 
   /**
@@ -18,13 +23,22 @@ export class RoomManager {
    * @returns {Promise<Object>} Created room object
    */
   createRoom(options = {}) {
+    const {
+      playerName,
+      playerId,
+      ...roomOptions
+    } = options;
+
     const roomConfig = {
-      name: options.name || 'New Room',
-      type: options.type || 'public',
-      gameMode: options.gameMode || 'default',
-      maxPlayers: options.maxPlayers || 4,
-      allowSpectators: options.allowSpectators !== false,
-      ...options
+      name: roomOptions.name ?? 'New Room',
+      type: roomOptions.type ?? 'public',
+      gameMode: roomOptions.gameMode ?? 'default',
+      maxPlayers: roomOptions.maxPlayers ?? 4,
+      allowSpectators:
+        roomOptions.allowSpectators !== undefined
+          ? roomOptions.allowSpectators
+          : true,
+      ...roomOptions
     };
 
     try {
@@ -43,7 +57,9 @@ export class RoomManager {
 
       this.rooms.set(roomId, room);
       this.currentRoom = room;
-      
+
+      this.ensurePlayerIdentity({ playerName, playerId });
+
       this.emit('roomCreated', room);
       console.log('Room created:', room);
       
@@ -66,29 +82,43 @@ export class RoomManager {
    * @param {string} roomId - Room ID to join
    * @returns {Promise<Object>} Room object
    */
-  joinRoom(roomId) {
+  joinRoom(roomId, options = {}) {
     try {
       const room = this.rooms.get(roomId);
-      
+
       if (!room) {
         throw new Error('Room not found. The room may have been deleted or the ID is incorrect.');
       }
 
-      if (room.players.length >= room.maxPlayers) {
+      const identity = this.ensurePlayerIdentity({
+        playerName: options.playerName,
+        playerId: options.playerId
+      });
+
+      let player = room.players.find(existing => existing.id === identity.id);
+
+      if (!player && room.players.length >= room.maxPlayers) {
         throw new Error('Room is full. Please try joining a different room.');
       }
 
-      // Add current player to room
-      const player = {
-        id: this.generatePlayerId(),
-        name: this.getPlayerName(),
-        isReady: false,
-        joinedAt: Date.now()
-      };
-
-      room.players.push(player);
+      if (!player) {
+        player = {
+          id: identity.id,
+          name: identity.name,
+          isReady: false,
+          joinedAt: Date.now(),
+          metadata: options.metadata ?? null
+        };
+        room.players.push(player);
+      } else {
+        player.name = identity.name;
+        if (options.metadata !== undefined) {
+          player.metadata = options.metadata;
+        }
+        player.lastJoinedAt = Date.now();
+      }
       this.currentRoom = room;
-      
+
       this.emit('roomJoined', room);
       console.log('Joined room:', room);
       
@@ -143,15 +173,22 @@ export class RoomManager {
       
       if (availableRooms.length > 0) {
         // Join first available room
-        return await this.joinRoom(availableRooms[0].id);
-      } 
-        // Create new room
-        return await this.createRoom({
-          name: 'Quick Play Room',
-          gameMode: options.gameMode || 'default',
-          maxPlayers: options.maxPlayers || 4
-        });
-      
+        return await this.joinRoom(availableRooms[0].id, options);
+      }
+      // Create and join a new room when none are available
+      const room = await this.createRoom({
+        name: 'Quick Play Room',
+        gameMode: options.gameMode ?? 'default',
+        maxPlayers: options.maxPlayers ?? 4,
+        type: options.type,
+        allowSpectators: options.allowSpectators,
+        playerName: options.playerName,
+        playerId: options.playerId
+      });
+
+      await this.joinRoom(room.id, options);
+      return room;
+
     } catch (error) {
       console.error('Quick play failed:', error);
       throw new Error(`Quick play failed: ${error.message}`);
@@ -260,17 +297,15 @@ export class RoomManager {
    * @returns {string} Player ID
    */
   getCurrentPlayerId() {
-    // This should be replaced with actual player ID from authentication
-    return 'current-player';
+    return this.ensurePlayerIdentity().id;
   }
 
   /**
-   * Get player name (placeholder implementation)
+   * Get player name from local identity state
    * @returns {string} Player name
    */
   getPlayerName() {
-    // This should be replaced with actual player name from authentication
-    return 'Player';
+    return this.ensurePlayerIdentity().name;
   }
 
   /**
@@ -316,6 +351,114 @@ export class RoomManager {
         }
       });
     }
+  }
+
+  /**
+   * Load stored player identity from persistent storage
+   * @returns {{id: string|null, name: string|null}}
+   */
+  loadStoredPlayerIdentity() {
+    if (typeof localStorage === 'undefined') {
+      return { id: null, name: null };
+    }
+
+    try {
+      return {
+        id: localStorage.getItem(PLAYER_ID_STORAGE_KEY),
+        name: localStorage.getItem(PLAYER_NAME_STORAGE_KEY)
+      };
+    } catch (error) {
+      console.warn('Unable to access player identity storage:', error);
+      return { id: null, name: null };
+    }
+  }
+
+  /**
+   * Persist player identity details if storage is available
+   * @param {{id: string, name: string}} identity - Identity to persist
+   */
+  persistPlayerIdentity(identity) {
+    if (typeof localStorage === 'undefined') {return;}
+
+    try {
+      if (identity.id) {
+        localStorage.setItem(PLAYER_ID_STORAGE_KEY, identity.id);
+      }
+      if (identity.name) {
+        localStorage.setItem(PLAYER_NAME_STORAGE_KEY, identity.name);
+      }
+    } catch (error) {
+      console.warn('Unable to persist player identity:', error);
+    }
+  }
+
+  /**
+   * Normalize player names and clamp to maximum length
+   * @param {string} name - Requested player name
+   * @returns {string} Normalized name or empty string when invalid
+   */
+  normalizePlayerName(name) {
+    if (name === null || name === undefined) {return '';}
+
+    const normalized = String(name).trim().replace(/\s+/g, ' ');
+    if (!normalized) {return '';}
+
+    return normalized.slice(0, MAX_PLAYER_NAME_LENGTH);
+  }
+
+  /**
+   * Generate a friendly fallback player name based on the current ID
+   * @param {string} id - Player identifier
+   * @returns {string} Generated player name
+   */
+  generateDefaultPlayerName(id) {
+    const cleanedId = (id || '').replace(/[^a-zA-Z0-9]/g, '');
+    const suffix = cleanedId.slice(-4).toUpperCase();
+
+    if (suffix) {
+      return `Player ${suffix}`;
+    }
+
+    const fallback = idGenerator.randomString(4, false).toUpperCase();
+    return `Player ${fallback}`;
+  }
+
+  /**
+   * Ensure the local player identity is populated and up to date
+   * @param {{playerName?: string, playerId?: string}} overrides - Overrides for identity
+   * @returns {{id: string, name: string}} Player identity
+   */
+  ensurePlayerIdentity(overrides = {}) {
+    const stored = this.localPlayer ?? this.loadStoredPlayerIdentity();
+    const identity = {
+      id: stored?.id ?? null,
+      name: stored?.name ?? null
+    };
+
+    if (typeof overrides.playerId === 'string') {
+      const trimmedId = overrides.playerId.trim();
+      if (trimmedId) {
+        identity.id = trimmedId;
+      }
+    }
+
+    const normalizedName = this.normalizePlayerName(overrides.playerName);
+    if (normalizedName) {
+      identity.name = normalizedName;
+    }
+
+    if (!identity.id) {
+      identity.id = this.generatePlayerId();
+    }
+
+    if (!identity.name) {
+      identity.name = this.generateDefaultPlayerName(identity.id);
+    }
+
+    this.localPlayer = identity;
+    this.persistPlayerIdentity(identity);
+
+    return identity;
   }
 
   /**

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -125,14 +125,14 @@ declare module 'trystero' {
   export const selfId: string
   
   // Room Manager exports
-  export {default as RoomManager} from './room-manager'
-  export {default as HostAuthority} from './host-authority'
-  export {default as RoomLobbyUI} from './room-lobby-ui'
+  export {default as RoomManager} from '../netcode/room-manager'
+  export {default as HostAuthority} from '../netcode/host-authority'
+  export {default as RoomLobbyUI} from '../netcode/room-lobby-ui'
   
   // Rollback Netcode exports
-  export {default as RollbackNetcode} from './rollback-netcode'
-  export {default as RollbackP2P} from './rollback-p2p'
-  export {RollbackLobby, HOSTING_MODE} from './rollback-lobby'
+  export {default as RollbackNetcode} from '../netcode/rollback-netcode'
+  export {default as RollbackP2P} from '../netcode/rollback-p2p'
+  export {RollbackLobby, HOSTING_MODE} from '../netcode/rollback-lobby'
   export {
     DeterministicGame,
     DeterministicRandom,
@@ -145,5 +145,5 @@ declare module 'trystero' {
     fixedSqrt,
     fixedSin,
     fixedCos
-  } from './deterministic-game'
+  } from '../netcode/deterministic-game'
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
-export {getRelaySockets, joinRoom, selfId} from './nostr.js'
+export {getRelaySockets, joinRoom, selfId} from '../netcode/nostr.js'
 export {default as RoomManager} from './room-manager.js'
-export {default as HostAuthority} from './host-authority.js'
-export {default as RoomLobbyUI} from './room-lobby-ui.js'
+export {default as HostAuthority} from '../host-authority.js'
+export {default as RoomLobbyUI} from '../netcode/room-lobby-ui.js'
 
 // Visual & Animation Features
 export {
@@ -12,7 +12,7 @@ export {
   CharacterAnimator,
   AnimationPresets,
   default as AnimationSystem
-} from './animation-system.js'
+} from '../animation/animation-system.js'
 export {default as CameraEffects} from './camera-effects.js'
 export {
   Particle,
@@ -37,16 +37,16 @@ export {
 export {
   EnhancedLobbyUI,
   default as EnhancedLobbyUIDefault
-} from './enhanced-lobby-ui.js'
+} from '../netcode/enhanced-lobby-ui.js'
 export {
   LobbyAnalytics,
   default as LobbyAnalyticsDefault
-} from './utils/lobby-analytics.js'
+} from './lobby-analytics.js'
 
 // Rollback Netcode exports
-export {default as RollbackNetcode} from './rollback-netcode.js'
-export {default as RollbackP2P} from './rollback-p2p.js'
-export {RollbackLobby, HOSTING_MODE} from './rollback-lobby.js'
+export {default as RollbackNetcode} from '../netcode/rollback-netcode.js'
+export {default as RollbackP2P} from '../netcode/rollback-p2p.js'
+export {RollbackLobby, HOSTING_MODE} from '../netcode/rollback-lobby.js'
 export {
   DeterministicGame,
   DeterministicRandom,
@@ -59,4 +59,4 @@ export {
   fixedSqrt,
   fixedSin,
   fixedCos
-} from './deterministic-game.js'
+} from '../netcode/deterministic-game.js'

--- a/src/utils/room-manager.js
+++ b/src/utils/room-manager.js
@@ -3,7 +3,7 @@
  * Handles room creation, listing, joining, and authority management
  */
 
-import { joinRoom as joinNostrRoom, selfId } from './nostr.js'
+import { joinRoom as joinNostrRoom, selfId } from '../netcode/nostr.js'
 import { toJson, fromJson, genId } from './utils.js'
 
 const ROOM_ANNOUNCE_INTERVAL = 5000 // 5 seconds


### PR DESCRIPTION
## Summary
- fix broken re-export paths in the utils entrypoint and generated documentation
- correct the nostr import in the utility room manager
- persist player identity information in the lobby room manager and support join options

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9107712c08333a07ceceb100dc11d