### PR TITLE
Ensure batched state sync emits phase change events

### DIFF
--- a/docs/js/src/game/game-state-manager.js
+++ b/docs/js/src/game/game-state-manager.js
@@ -249,7 +249,13 @@ export class GameStateManager {
 
     // Update game phase (maintain compatibility with legacy property)
     const safePhase = Number.isFinite(playerState.phase) ? playerState.phase : this.phaseState.currentPhase;
-    this.phaseState.currentPhase = safePhase;
+    const previousPhase = this.phaseState.currentPhase;
+
+    if (safePhase !== previousPhase) {
+      this.phaseState.currentPhase = safePhase;
+      this.emit('phaseChanged', safePhase);
+    }
+
     this.currentPhase = safePhase;
 
     // Update camera to follow player

--- a/src/game/game-state-manager.js
+++ b/src/game/game-state-manager.js
@@ -261,7 +261,13 @@ export class GameStateManager {
 
     // Update game phase (maintain compatibility with legacy property)
     const safePhase = Number.isFinite(playerState.phase) ? playerState.phase : this.phaseState.currentPhase;
-    this.phaseState.currentPhase = safePhase;
+    const previousPhase = this.phaseState.currentPhase;
+
+    if (safePhase !== previousPhase) {
+      this.phaseState.currentPhase = safePhase;
+      this.emit('phaseChanged', safePhase);
+    }
+
     this.currentPhase = safePhase;
 
     // Update camera to follow player


### PR DESCRIPTION
## Summary
- emit the `phaseChanged` event from the batched state sync when the WASM phase differs from the cached value
- mirror the phase change handling fix in the docs bundle to keep both outputs aligned

## Testing
- npx mocha test/unit/game-state-manager.test.js --grep "synchronize position"

------
https://chatgpt.com/codex/tasks/task_e_68c924f4ff208333be721aa30b3b09ef