### PR TITLE
Fix deploy workflow PowerShell setup action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Install PowerShell
-        uses: actions/setup-pwsh@v2
+        uses: actions/setup-powershell@v2
         
       - name: Build docs
         run: npm run build:docs


### PR DESCRIPTION
## Summary
- replace the deploy workflow's PowerShell setup step to use actions/setup-powershell@v2 instead of the nonexistent setup-pwsh action

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c9973917588333a4a9c56235c14ccd