### PR TITLE
Run build and dependency tests

### DIFF
--- a/rollup.config.animations.js
+++ b/rollup.config.animations.js
@@ -1,0 +1,60 @@
+import resolve from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
+
+const ecma = 2019
+
+const ignoreCodes = new Set(['THIS_IS_UNDEFINED'])
+const onwarn = (warning, warn) => {
+  if (ignoreCodes.has(warning.code)) return
+  warn(warning)
+}
+
+export default {
+  onwarn,
+  context: 'globalThis',
+  input: 'src/animation/player-animator.js',
+  output: [
+    {
+      file: 'dist/player-animator.js',
+      format: 'es',
+      sourcemap: true,
+      sourcemapFile: 'dist/player-animator.js.map'
+    },
+    {
+      file: 'dist/player-animator.min.js',
+      format: 'es',
+      compact: true,
+      plugins: [
+        terser({
+          compress: {
+            ecma,
+            drop_console: ['log', 'info'],
+            keep_fargs: false,
+            module: true,
+            toplevel: true,
+            unsafe: true,
+            unsafe_arrows: true,
+            unsafe_methods: true,
+            unsafe_proto: true,
+            unsafe_symbols: true
+          },
+          format: {comments: false, ecma},
+          mangle: {module: true, toplevel: true}
+        })
+      ]
+    },
+    {
+      file: 'dist/player-animator.umd.js',
+      format: 'umd',
+      exports: 'named',
+      name: 'AnimatedPlayer',
+      sourcemap: true,
+      sourcemapFile: 'dist/player-animator.umd.js.map'
+    }
+  ],
+  plugins: [resolve({browser: true, preferBuiltins: false})],
+  external: [
+    './sound-system.js',
+    './particle-system.js'
+  ]
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,61 @@
+import commonJs from '@rollup/plugin-commonjs'
+import replace from '@rollup/plugin-replace'
+import resolve from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
+
+const ecma = 2019
+const nodeEnv = '"production"'
+
+const ignoreCodes = new Set(['THIS_IS_UNDEFINED', 'CIRCULAR_DEPENDENCY'])
+
+const onwarn = (warning, warn) => {
+  if (ignoreCodes.has(warning.code)) return
+  warn(warning)
+}
+
+const baseConfig = {
+  onwarn,
+  context: 'globalThis',
+  output: {
+    compact: true,
+    format: 'es',
+    inlineDynamicImports: true,
+    sourcemap: false  // Disable source maps for production builds
+  },
+  plugins: [
+    resolve({browser: true, preferBuiltins: false}),
+    commonJs(),
+    replace({
+      'process.env.NODE_ENV': nodeEnv,
+      'process?.env?.NODE_ENV': nodeEnv,
+      preventAssignment: true
+    }),
+    terser({
+      compress: {
+        ecma,
+        drop_console: ['log', 'info'],
+        keep_fargs: false,
+        module: true,
+        toplevel: true,
+        unsafe: true,
+        unsafe_arrows: true,
+        unsafe_methods: true,
+        unsafe_proto: true,
+        unsafe_symbols: true
+      },
+      format: {comments: false, ecma},
+      mangle: {module: true, toplevel: true}
+    })
+  ]
+}
+
+export default ['firebase', 'ipfs', 'mqtt', 'nostr', 'supabase', 'torrent', 'wasm'].map(
+  name => ({
+    ...baseConfig,
+    input: name === 'wasm' ? `src/utils/${name}.js` : `src/netcode/${name}.js`,
+    output: {
+      ...baseConfig.output,
+      file: `dist/trystero-${name}.min.js`
+    }
+  })
+)

--- a/rollup.config.wolf.js
+++ b/rollup.config.wolf.js
@@ -1,0 +1,59 @@
+import resolve from '@rollup/plugin-node-resolve'
+import terser from '@rollup/plugin-terser'
+
+const ecma = 2019
+
+const ignoreCodes = new Set(['THIS_IS_UNDEFINED'])
+const onwarn = (warning, warn) => {
+  if (ignoreCodes.has(warning.code)) return
+  warn(warning)
+}
+
+export default {
+  onwarn,
+  context: 'globalThis',
+  input: 'src/animation/wolf-animation.js',
+  output: [
+    {
+      file: 'dist/wolf-animation.js',
+      format: 'es',
+      sourcemap: true,
+      sourcemapFile: 'dist/wolf-animation.js.map'
+    },
+    {
+      file: 'dist/wolf-animation.min.js',
+      format: 'es',
+      compact: true,
+      plugins: [
+        terser({
+          compress: {
+            ecma,
+            drop_console: ['log', 'info'],
+            keep_fargs: false,
+            module: true,
+            toplevel: true,
+            unsafe: true,
+            unsafe_arrows: true,
+            unsafe_methods: true,
+            unsafe_proto: true,
+            unsafe_symbols: true
+          },
+          format: {comments: false, ecma},
+          mangle: {module: true, toplevel: true}
+        })
+      ]
+    },
+    {
+      file: 'dist/wolf-animation.umd.js',
+      format: 'umd',
+      exports: 'named',
+      name: 'WolfAnimationSystem',
+      sourcemap: true,
+      sourcemapFile: 'dist/wolf-animation.umd.js.map'
+    }
+  ],
+  plugins: [resolve({browser: true, preferBuiltins: false})],
+  external: [
+    './particle-system.js'
+  ]
+}


### PR DESCRIPTION
Add Rollup configuration files to the root directory to fix failing build tests.

The `npm run test:build` command was failing because the test suite expected `rollup.config.js`, `rollup.config.animations.js`, and `rollup.config.wolf.js` to be present in the project's root directory. These files originally resided in `tools/config/`. This PR creates copies of these configuration files in the root to satisfy the test requirements, allowing all build-related tests to pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-907976e1-0fd4-4167-9a96-38f78f09a1b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-907976e1-0fd4-4167-9a96-38f78f09a1b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

