### PR TITLE
Debug wasm source code

### DIFF
--- a/src/wasm/enemies.h
+++ b/src/wasm/enemies.h
@@ -1039,6 +1039,8 @@ static inline void expire_dangers() {
       if (i <= last) {
         g_dangers[i] = g_dangers[last];
         if (g_danger_count > 0) g_danger_count--;
+        // Re-check current index since we moved an element here
+        i--;
       }
     }
   }

--- a/src/wasm/terrain_hazards.h
+++ b/src/wasm/terrain_hazards.h
@@ -119,6 +119,9 @@ static inline void apply_hazard_damage(float damage, HazardType type) {
   g_hp -= damage;
   if (g_hp < 0.f) g_hp = 0.f;
   
+  // Sync with save system health
+  g_health = (int)(g_hp * g_max_health);
+  
   g_last_hazard_damage_time = g_time_seconds;
   
   // Apply status effects based on hazard type


### PR DESCRIPTION
Fixes several bugs in `src/wasm`, including array element skipping, health system synchronization, and a duplicate variable declaration.

When removing elements from dynamic arrays by swapping with the last element, the loop index `i` was not decremented, causing the newly moved element at `i` to be skipped in the next iteration. The game also had two health variables (`g_hp` for gameplay, `g_health` for save state) that were not consistently synchronized, leading to potential discrepancies. Finally, `g_is_wall_sliding` was declared as `static int` in a header but redeclared as `static bool` in a `.cpp` file, causing shadowing and type inconsistencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c069c0d-f1f0-45df-93c7-5d44af00db6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c069c0d-f1f0-45df-93c7-5d44af00db6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

