### PR TITLE
Run build tests and fix failures

### DIFF
--- a/BUILD_REPORT.json
+++ b/BUILD_REPORT.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": "2025-09-21T19:38:04.010Z",
-  "duration": 39117,
+  "timestamp": "2025-09-26T19:45:00.191Z",
+  "duration": 55536,
   "stats": {
     "modulesBuilt": 3,
-    "totalSize": 1770334,
+    "totalSize": 1760432,
     "optimizationSavings": 0,
     "errors": [],
     "warnings": [
@@ -19,12 +19,12 @@
       "core/trystero-supabase.min.js": 127,
       "core/trystero-torrent.min.js": 13,
       "core/trystero-wasm.min.js": 4,
-      "animations/player-animator.js": 129,
+      "animations/player-animator.js": 126,
       "animations/player-animator.min.js": 47,
-      "animations/player-animator.umd.js": 141,
-      "animations/wolf-animation.js": 78,
+      "animations/player-animator.umd.js": 138,
+      "animations/wolf-animation.js": 76,
       "animations/wolf-animation.min.js": 31,
-      "animations/wolf-animation.umd.js": 86,
+      "animations/wolf-animation.umd.js": 84,
       "core/index.js": 1,
       "animations/index.js": 1,
       "index.js": 0

--- a/BUILD_REPORT.md
+++ b/BUILD_REPORT.md
@@ -1,12 +1,12 @@
 # Build Report
 
-Generated: 2025-09-21T19:38:04.010Z
-Duration: 39117ms
+Generated: 2025-09-26T19:45:00.191Z
+Duration: 55536ms
 
 ## Summary
 
 - **Modules Built**: 3
-- **Total Size**: 1729KB
+- **Total Size**: 1719KB
 - **Optimization Savings**: 0 bytes
 - **Errors**: 0
 - **Warnings**: 3
@@ -20,12 +20,12 @@ Duration: 39117ms
 - **core/trystero-supabase.min.js**: 127KB
 - **core/trystero-torrent.min.js**: 13KB
 - **core/trystero-wasm.min.js**: 4KB
-- **animations/player-animator.js**: 129KB
+- **animations/player-animator.js**: 126KB
 - **animations/player-animator.min.js**: 47KB
-- **animations/player-animator.umd.js**: 141KB
-- **animations/wolf-animation.js**: 78KB
+- **animations/player-animator.umd.js**: 138KB
+- **animations/wolf-animation.js**: 76KB
 - **animations/wolf-animation.min.js**: 31KB
-- **animations/wolf-animation.umd.js**: 86KB
+- **animations/wolf-animation.umd.js**: 84KB
 - **core/index.js**: 1KB
 - **animations/index.js**: 1KB
 - **index.js**: 0KB

--- a/test/unit/build.test.js
+++ b/test/unit/build.test.js
@@ -67,7 +67,7 @@ describe('Build System', () => {
     before(function() {
       // Run build before testing outputs
       // Increase timeout for build process
-      this.timeout(30000);
+      this.timeout(120000);
       
       try {
         // Check if dependencies are installed
@@ -89,7 +89,7 @@ describe('Build System', () => {
     });
 
     it('should generate firebase bundle', () => {
-      const filePath = path.join(distDir, 'trystero-firebase.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-firebase.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -97,7 +97,7 @@ describe('Build System', () => {
     });
 
     it('should generate ipfs bundle', () => {
-      const filePath = path.join(distDir, 'trystero-ipfs.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-ipfs.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -105,7 +105,7 @@ describe('Build System', () => {
     });
 
     it('should generate mqtt bundle', () => {
-      const filePath = path.join(distDir, 'trystero-mqtt.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-mqtt.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -114,7 +114,7 @@ describe('Build System', () => {
 
 
     it('should generate supabase bundle', () => {
-      const filePath = path.join(distDir, 'trystero-supabase.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-supabase.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -122,7 +122,7 @@ describe('Build System', () => {
     });
 
     it('should generate torrent bundle', () => {
-      const filePath = path.join(distDir, 'trystero-torrent.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-torrent.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -130,7 +130,7 @@ describe('Build System', () => {
     });
 
     it('should generate wasm bundle', () => {
-      const filePath = path.join(distDir, 'trystero-wasm.min.js');
+      const filePath = path.join(distDir, 'core', 'trystero-wasm.min.js');
       expect(fs.existsSync(filePath)).to.be.true;
       
       const stats = fs.statSync(filePath);
@@ -139,7 +139,7 @@ describe('Build System', () => {
 
     it('should generate minified bundles', () => {
       // Check that bundles are actually minified by checking for typical minification patterns
-      const firebaseBundle = fs.readFileSync(path.join(distDir, 'trystero-firebase.min.js'), 'utf8');
+      const firebaseBundle = fs.readFileSync(path.join(distDir, 'core', 'trystero-firebase.min.js'), 'utf8');
       
       // Minified code typically has very long lines
       const lines = firebaseBundle.split('\n');
@@ -155,7 +155,7 @@ describe('Build System', () => {
   describe('Animation Build Output', () => {
     before(function() {
       // Run animation build
-      this.timeout(30000);
+      this.timeout(60000);
       
       try {
         console.log('Running animation build...');
@@ -173,7 +173,7 @@ describe('Build System', () => {
       ];
       
       files.forEach(file => {
-        const filePath = path.join(distDir, file);
+        const filePath = path.join(distDir, 'animations', file);
         expect(fs.existsSync(filePath)).to.be.true;
         
         const stats = fs.statSync(filePath);
@@ -185,7 +185,7 @@ describe('Build System', () => {
   describe('Wolf Build Output', () => {
     before(function() {
       // Run wolf build
-      this.timeout(30000);
+      this.timeout(60000);
       
       try {
         console.log('Running wolf build...');
@@ -203,7 +203,7 @@ describe('Build System', () => {
       ];
       
       files.forEach(file => {
-        const filePath = path.join(distDir, file);
+        const filePath = path.join(distDir, 'animations', file);
         expect(fs.existsSync(filePath)).to.be.true;
         
         const stats = fs.statSync(filePath);
@@ -240,8 +240,8 @@ describe('Build System', () => {
         'src/netcode/supabase.js',
         'src/netcode/torrent.js',
         'src/utils/wasm.js',
-        'src/animation/player-animator.js',
-        'src/animation/wolf-animation.js'
+        'src/animation/player/procedural/player-animator.js',
+        'src/animation/enemy/wolf-animation.js'
       ];
       
       sourceFiles.forEach(file => {

--- a/tools/scripts/dist-organizer.js
+++ b/tools/scripts/dist-organizer.js
@@ -123,21 +123,20 @@ class DistOrganizer {
   async moveFilesToDirectories() {
     console.log(chalk.blue('📦 Moving files to organized directories...'));
     
-    // Move files to their respective directories
+    // Files are already in the correct structure from the build process
+    // Just verify they exist and log their locations
     for (const [directory, files] of Object.entries(this.organizedStructure)) {
       const targetDir = path.join(this.distPath, directory);
       
       for (const file of files) {
-        const sourcePath = path.join(this.distPath, file);
         const targetPath = path.join(targetDir, file);
         
         try {
-          await fs.access(sourcePath);
-          await fs.rename(sourcePath, targetPath);
-          console.log(chalk.green(`  ✓ Moved ${file} → ${directory}`));
+          await fs.access(targetPath);
+          console.log(chalk.green(`  ✓ Found ${file} in ${directory}`));
         } catch (error) {
           if (error.code === 'ENOENT') {
-            console.log(chalk.yellow(`  ⚠ ${file} not found (may not be built yet)`));
+            console.log(chalk.yellow(`  ⚠ ${file} not found in ${directory} (may not be built yet)`));
           } else {
             throw error;
           }


### PR DESCRIPTION
Fixes failing build tests by updating file paths and build process logic.

Tests and the dist organizer expected bundles directly in `dist/`, but the build process outputs them into `dist/core/` and `dist/animations/`. This PR updates the test file to check the correct paths, fixes animation source file paths, and adjusts the dist organizer to verify existing files rather than attempting to move them. Test timeouts were also increased to accommodate the build duration.

---
<a href="https://cursor.com/background-agent?bcId=bc-e134f0e4-73f6-406e-ac1d-c0845c3e6d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e134f0e4-73f6-406e-ac1d-c0845c3e6d29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

