### PR TITLE
Remove non-existent build:docs script

### DIFF
--- a/GUIDELINES/UTILS/DEPLOY_GITHUB_PAGES.md
+++ b/GUIDELINES/UTILS/DEPLOY_GITHUB_PAGES.md
@@ -82,9 +82,9 @@ The automated deployment pipeline executes the following stages:
 1. **Checkout** - Gets the latest code from your repository
 2. **Setup Node.js** - Installs Node.js version 20
 3. **Install dependencies** - Runs `npm ci` to install packages
-4. **Build project** - Runs `npm run build:docs` which:
+4. **Build project** - Runs `npm run build` which:
    - Builds the project with Rollup
-   - Copies built files to the docs folder
+   - Copies built files to the public folder
 5. **Upload artifact** - Packages the docs folder for deployment
 6. **Deploy** - Publishes the site to GitHub Pages
 
@@ -99,12 +99,12 @@ Before deploying to production, test your site locally:
 npm install
 
 # Build the project
-npm run build:docs
+npm run build
 
-# Serve the docs folder locally
-npx serve docs
+# Serve the public folder locally
+npx serve public
 # Or use any static server:
-# python -m http.server 8000 -d docs
+# python -m http.server 8000 -d public
 ```
 
 ## 🌐 Custom Domain Configuration
@@ -180,8 +180,8 @@ The GitHub Actions workflow will automatically build and deploy your changes.
 
 For manual control over deployment:
 
-1. Build locally: `npm run build:docs`
-2. Commit the docs folder: `git add docs && git commit -m "Update docs"`
+1. Build locally: `npm run build`
+2. Commit the public folder: `git add public && git commit -m "Update docs"`
 3. Push to GitHub: `git push origin main`
 
 ## 📝 Important Notes

--- a/test/unit/github-pages-deployment.test.js
+++ b/test/unit/github-pages-deployment.test.js
@@ -191,7 +191,7 @@ describe('GitHub Pages Deployment', () => {
   });
 
   describe('Build Process Integration', () => {
-    it('should successfully run build:docs command', function() {
+    it('should successfully run build:public command', function() {
       this.timeout(30000); // Allow 30 seconds for build
       
       try {
@@ -228,7 +228,7 @@ describe('GitHub Pages Deployment', () => {
         });
       } catch (error) {
         // If build fails, provide helpful error message
-        throw new Error(`Build:docs command failed: ${error.message}`);
+        throw new Error(`Build:public command failed: ${error.message}`);
       }
     });
   });

--- a/tools/scripts/deploy.sh
+++ b/tools/scripts/deploy.sh
@@ -24,7 +24,7 @@ npm run build:all
 
 # Build documentation
 echo "📚 Building documentation..."
-npm run build:docs
+npm run build:public
 
 # Dist folder is already in root, no need to copy
 


### PR DESCRIPTION
Remove references to the missing `build:docs` script by updating them to use existing `build` or `build:public` commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4d149ae-4a95-4ad3-8d3d-fc624f2b173e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4d149ae-4a95-4ad3-8d3d-fc624f2b173e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

