### PR TITLE
Refactor player rendering to procedural

### DIFF
--- a/public/src/utils/game-renderer.js
+++ b/public/src/utils/game-renderer.js
@@ -86,6 +86,7 @@ import {
   drawWeapon as _drawWeapon,
   drawBow as _drawBow,
   drawShield as _drawShield,
+  drawProceduralPlayer as _drawProceduralPlayer,
   renderPlayer as _renderPlayer,
 } from './renderer/characters.js';
 import {
@@ -304,6 +305,7 @@ export class GameRenderer {
   drawHealthPickup(x, y, size) { return _drawHealthPickup(this, x, y, size); }
 
   // Characters/effects
+  drawProceduralPlayer(state, position, baseRadius, transform) { return _drawProceduralPlayer(this, state, position, baseRadius, transform); }
   drawEnhancedCharacter(x, y, width, height, color, facing, state, stateTimer, effects) { return _drawEnhancedCharacter(this, x, y, width, height, color, facing, state, stateTimer, effects); }
   drawCharacter(x, y, width, height, color, facing, state, _frame) { return _drawCharacter(this, x, y, width, height, color, facing, state, _frame); }
   drawWeaponTrail(pos, facing, stateTimer) { return _drawWeaponTrail(this, pos, facing, stateTimer); }


### PR DESCRIPTION
Migrate main game player rendering to procedural-only, leveraging `CharacterAnimator` for dynamic visualization with trails and secondary motion instead of sprite sheets.

---
<a href="https://cursor.com/background-agent?bcId=bc-39a072a4-d0d2-433e-9300-b6b94b88c803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39a072a4-d0d2-433e-9300-b6b94b88c803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

