### PR TITLE
Find and fix bugs

### DIFF
--- a/public/src/demo/main.js
+++ b/public/src/demo/main.js
@@ -174,8 +174,7 @@ const buildOverlay = (state, now) => {
     wasmApi.exports.set_blocking(
       block,
       inputManager.lastMovementDirection.x,
-      inputManager.lastMovementDirection.y,
-      performance.now() / 1000
+      inputManager.lastMovementDirection.y
     );
   }
 

--- a/public/src/demo/wasm-api.js
+++ b/public/src/demo/wasm-api.js
@@ -453,7 +453,7 @@ const createApiFromRuntime = (runtime, optionalDefaults, contractSet) => {
   
   // Ensure player starts with clean input state after initialization
   if (handles.set_blocking) {
-    handles.set_blocking(0, 0, 0, performance.now() / 1000);
+    handles.set_blocking(0, 0, 0);
   }
   
   // Also clear all inputs to ensure clean start
@@ -535,7 +535,7 @@ const createApiFromRuntime = (runtime, optionalDefaults, contractSet) => {
         }
         // Force-clear in WASM if export exists
         if (api.exports && typeof api.exports.set_blocking === 'function') {
-          api.exports.set_blocking(0, 0, 0, performance.now() / 1000);
+          api.exports.set_blocking(0, 0, 0);
         }
       } catch (e) {
         console.warn('[Demo] unblock() failed:', e.message);
@@ -551,7 +551,7 @@ const createApiFromRuntime = (runtime, optionalDefaults, contractSet) => {
         }
         // Also call direct blocking export if present
         if (api.exports && typeof api.exports.set_blocking === 'function') {
-          api.exports.set_blocking(v, 0, 0, performance.now() / 1000);
+          api.exports.set_blocking(v, 0, 0);
         }
       } catch (e) {
         console.warn('[Demo] forceBlock() failed:', e.message);

--- a/public/src/managers/unified-input-manager.js
+++ b/public/src/managers/unified-input-manager.js
@@ -553,7 +553,7 @@ export class UnifiedInputManager {
             // Also explicitly clear blocking state if the function exists
             if (this.wasmManager?.exports?.set_blocking) {
                 try {
-                    this.wasmManager.exports.set_blocking(0, 0, 0, performance.now() / 1000);
+                    this.wasmManager.exports.set_blocking(0, 0, 0);
                 } catch (e) {
                     console.warn('Failed to clear blocking state:', e);
                 }


### PR DESCRIPTION
Fix WASM `set_blocking` function signature mismatch by removing an extraneous `time` parameter from its calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-92abaed4-6fbf-4a67-8545-2170fa6c5aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92abaed4-6fbf-4a67-8545-2170fa6c5aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

