### PR TITLE
Setup emscripten compiler for wasm builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         
     - name: Setup Emscripten SDK
       run: |
+        rm -rf emsdk
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
         ./emsdk install latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,16 +34,10 @@ jobs:
         
     - name: Install dependencies
       run: npm ci
-      
-    - name: Install PowerShell Core
-      run: |
-        wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
-        sudo dpkg -i packages-microsoft-prod.deb
-        sudo apt-get update
-        sudo apt-get install -y powershell
         
     - name: Setup Emscripten SDK
       run: |
+        git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
         ./emsdk install latest
         ./emsdk activate latest
@@ -54,7 +48,9 @@ jobs:
       run: npm run balance:gen
       
     - name: Build WASM modules
-      run: npm run wasm:build:all
+      run: |
+        source emsdk/emsdk_env.sh
+        npm run wasm:build:all
       
     - name: Build project
       run: npm run build:all


### PR DESCRIPTION
Fix CI workflow to properly install Emscripten and remove unnecessary PowerShell installation for WASM builds.

The previous workflow failed because the Emscripten SDK was not correctly cloned and its environment variables were not persistently sourced for the WASM build step. Additionally, an unnecessary PowerShell Core installation step was removed, as it's not required on Linux runners and contributed to build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-adeaef02-4f84-41ba-b4dc-10b74f6dc6a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-adeaef02-4f84-41ba-b4dc-10b74f6dc6a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

