### PR TITLE
Add wasm build to deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Build project
       run: |
         source emsdk/emsdk_env.sh
+        npm run wasm:build
         npm run build
         
     - name: Setup Pages

--- a/tools/scripts/enhanced-build.js
+++ b/tools/scripts/enhanced-build.js
@@ -58,26 +58,29 @@ class EnhancedBuildSystem {
         await this.cleanDistDirectory();
       }
       
-      // 3. Run builds in parallel
+      // 3. Build WASM files
+      await this.buildWasm();
+      
+      // 4. Run builds in parallel
       await this.runBuilds();
       
-      // 4. Post-build optimization
+      // 5. Post-build optimization
       if (this.config.optimize) {
         await this.runPostBuildOptimization();
       }
       
-      // 5. Validate builds
+      // 6. Validate builds
       if (this.config.validate) {
         await this.validateBuilds();
       }
       
-      // 6. Copy WASM files
+      // 7. Copy WASM files
       await this.copyWasmFiles();
       
-      // 7. Organize dist folder structure
+      // 8. Organize dist folder structure
       await this.organizeDistFolder();
       
-      // 8. Generate report
+      // 9. Generate report
       if (this.config.generateReport) {
         await this.generateBuildReport();
       }
@@ -133,6 +136,28 @@ class EnhancedBuildSystem {
     } catch (error) {
       // Dist directory doesn't exist, that's fine
       console.log(chalk.yellow('ℹ Dist directory does not exist, will be created'));
+    }
+  }
+
+  /**
+   * Build WASM files
+   */
+  async buildWasm() {
+    console.log(chalk.blue('🔧 Building WASM files...'));
+    
+    try {
+      const startTime = Date.now();
+      execSync('npm run wasm:build', {
+        cwd: projectRoot,
+        stdio: 'inherit'
+      });
+      const duration = Date.now() - startTime;
+      console.log(chalk.green(`✓ WASM build completed successfully (${duration}ms)`));
+    } catch (error) {
+      // WASM build failure is not fatal - log warning and continue
+      const warning = `WASM build failed: ${error.message}`;
+      this.buildStats.warnings.push(warning);
+      console.log(chalk.yellow(`⚠ ${warning} - continuing with build process`));
     }
   }
 


### PR DESCRIPTION
Add `npm run wasm:build` to the GitHub workflow and enhanced build script to ensure WASM files are built during deployment and local builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9410d21-a434-492d-96af-5f011c40d859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9410d21-a434-492d-96af-5f011c40d859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

