### PR TITLE
Fix test skeleton demo html

### DIFF
--- a/public/demos/test-skeleton-demo.html
+++ b/public/demos/test-skeleton-demo.html
@@ -123,8 +123,8 @@ npm run demo:skeleton</pre>
             
             // Test 2: Check for WASM module
             try {
-                const jsResponse = await fetch('../wasm/skeleton-physics.js');
-                const wasmResponse = await fetch('../wasm/skeleton-physics.wasm');
+                const jsResponse = await fetch('/wasm/skeleton-physics.js');
+                const wasmResponse = await fetch('/wasm/skeleton-physics.wasm');
                 
                 if (jsResponse.ok && wasmResponse.ok) {
                     addResult('WASM Module', true, 
@@ -143,7 +143,7 @@ npm run demo:skeleton</pre>
             
             // Test 4: Check C++ source
             try {
-                const response = await fetch('../wasm/skeleton-physics.cpp');
+                const response = await fetch('/wasm/skeleton-physics.cpp');
                 addResult(
                     'C++ Source',
                     response.ok,
@@ -157,7 +157,7 @@ npm run demo:skeleton</pre>
             
             // Test 5: Check build script
             try {
-                const response = await fetch('../wasm/build-skeleton-physics.sh');
+                const response = await fetch('/wasm/build-skeleton-physics.sh');
                 addResult(
                     'Build Script',
                     response.ok,


### PR DESCRIPTION
Update file paths in `test-skeleton-demo.html` to use absolute paths for WASM-related files.

The previous relative paths (`../wasm/`) were incorrect when the HTML demo file was served from `public/demos/`, leading to failed file fetches. Changing them to absolute paths (`/wasm/`) ensures they are correctly resolved from the web root.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8497d01-7c32-45e6-8b69-06f28631565f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8497d01-7c32-45e6-8b69-06f28631565f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

