### PR TITLE
Fix capsule geometry constructor error

### DIFF
--- a/public/demos/interactive-skeleton-physics.html
+++ b/public/demos/interactive-skeleton-physics.html
@@ -321,7 +321,7 @@
         <div>• Scroll: Zoom</div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r140/three.min.js"></script>
     <script type="module">
         // ============================================================================
         // WASM MODULE LOADER (with fallback to pure JS)


### PR DESCRIPTION
Update Three.js version to r140 to enable `THREE.CapsuleGeometry`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7b94b77-a87a-409b-a670-d6bab1a00bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7b94b77-a87a-409b-a670-d6bab1a00bc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

